### PR TITLE
Set command name in getDefaultName to prevent DIC registration during app startup

### DIFF
--- a/src/Command/MigrationCheckCommand.php
+++ b/src/Command/MigrationCheckCommand.php
@@ -29,11 +29,14 @@ class MigrationCheckCommand extends Command
         $this->migrationService = $migrationService;
     }
 
+    public static function getDefaultName(): string
+    {
+        return 'migration:check';
+    }
+
     protected function configure(): void
     {
-        $this
-            ->setName('migration:check')
-            ->setDescription('Check if entities are in sync with database and if migrations were executed');
+        $this->setDescription('Check if entities are in sync with database and if migrations were executed');
     }
 
     public function run(InputInterface $input, OutputInterface $output): int

--- a/src/Command/MigrationGenerateCommand.php
+++ b/src/Command/MigrationGenerateCommand.php
@@ -21,11 +21,14 @@ class MigrationGenerateCommand extends Command
         $this->migrationService = $migrationService;
     }
 
+    public static function getDefaultName(): string
+    {
+        return 'migration:generate';
+    }
+
     protected function configure(): void
     {
-        $this
-            ->setName('migration:generate')
-            ->setDescription('Generate migration class');
+        $this->setDescription('Generate migration class');
     }
 
     public function run(InputInterface $input, OutputInterface $output): int

--- a/src/Command/MigrationInitCommand.php
+++ b/src/Command/MigrationInitCommand.php
@@ -21,11 +21,14 @@ class MigrationInitCommand extends Command
         $this->migrationService = $migrationService;
     }
 
+    public static function getDefaultName(): string
+    {
+        return 'migration:init';
+    }
+
     protected function configure(): void
     {
-        $this
-            ->setName('migration:init')
-            ->setDescription('Create migration table in database');
+        $this->setDescription('Create migration table in database');
     }
 
     public function run(InputInterface $input, OutputInterface $output): int

--- a/src/Command/MigrationRunCommand.php
+++ b/src/Command/MigrationRunCommand.php
@@ -31,10 +31,14 @@ class MigrationRunCommand extends Command
         $this->migrationService = $migrationService;
     }
 
+    public static function getDefaultName(): string
+    {
+        return 'migration:run';
+    }
+
     protected function configure(): void
     {
         $this
-            ->setName('migration:run')
             ->setDescription('Run all not executed migrations with specified phase')
             ->addArgument(self::ARGUMENT_PHASE, InputArgument::REQUIRED, MigrationPhase::BEFORE . '|' . MigrationPhase::AFTER . '|' . self::PHASE_BOTH);
     }

--- a/src/Command/MigrationSkipCommand.php
+++ b/src/Command/MigrationSkipCommand.php
@@ -22,11 +22,14 @@ class MigrationSkipCommand extends Command
         $this->migrationService = $migrationService;
     }
 
+    public static function getDefaultName(): string
+    {
+        return 'migration:skip';
+    }
+
     protected function configure(): void
     {
-        $this
-            ->setName('migration:skip')
-            ->setDescription('Mark all not executed migrations as executed in both phases');
+        $this->setDescription('Mark all not executed migrations as executed in both phases');
     }
 
     public function run(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
Setting the default name for commands allows symfony container to register commands in a lazy way whereas setting the name in `configure` creates these services even when they are not required during application startup.

Before:
<img width="882" alt="Screenshot 2023-08-25 at 09 50 37" src="https://github.com/shipmonk-rnd/doctrine-two-phase-migrations/assets/3778875/1526ab33-a7d4-46e8-a4b2-2a32fa27df9e">

After:
<img width="882" alt="Screenshot 2023-08-25 at 09 50 55" src="https://github.com/shipmonk-rnd/doctrine-two-phase-migrations/assets/3778875/55a1b9c1-fe35-4b42-a3f1-2f617050152d">
