### PR TITLE
Commands: use execute method, not run

### DIFF
--- a/src/Command/MigrationCheckCommand.php
+++ b/src/Command/MigrationCheckCommand.php
@@ -40,7 +40,7 @@ class MigrationCheckCommand extends Command
         $this->setDescription('Check if entities are in sync with database and if migrations were executed');
     }
 
-    public function run(InputInterface $input, OutputInterface $output): int
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $exitCode = self::EXIT_OK;
         $exitCode |= $this->checkMigrationsExecuted($output);

--- a/src/Command/MigrationGenerateCommand.php
+++ b/src/Command/MigrationGenerateCommand.php
@@ -31,7 +31,7 @@ class MigrationGenerateCommand extends Command
         $this->setDescription('Generate migration class');
     }
 
-    public function run(InputInterface $input, OutputInterface $output): int
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $sqls = $this->migrationService->generateDiffSqls();
 

--- a/src/Command/MigrationInitCommand.php
+++ b/src/Command/MigrationInitCommand.php
@@ -31,7 +31,7 @@ class MigrationInitCommand extends Command
         $this->setDescription('Create migration table in database');
     }
 
-    public function run(InputInterface $input, OutputInterface $output): int
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->write('<comment>Creating migration table... </comment>');
         $initialized = $this->migrationService->initializeMigrationTable();

--- a/src/Command/MigrationRunCommand.php
+++ b/src/Command/MigrationRunCommand.php
@@ -43,7 +43,7 @@ class MigrationRunCommand extends Command
             ->addArgument(self::ARGUMENT_PHASE, InputArgument::REQUIRED, MigrationPhase::BEFORE . '|' . MigrationPhase::AFTER . '|' . self::PHASE_BOTH);
     }
 
-    public function run(InputInterface $input, OutputInterface $output): int
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $phaseArgument = $input->getArgument(self::ARGUMENT_PHASE);
 

--- a/src/Command/MigrationSkipCommand.php
+++ b/src/Command/MigrationSkipCommand.php
@@ -32,7 +32,7 @@ class MigrationSkipCommand extends Command
         $this->setDescription('Mark all not executed migrations as executed in both phases');
     }
 
-    public function run(InputInterface $input, OutputInterface $output): int
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $skipped = false;
 

--- a/tests/Command/MigrationRunCommandTest.php
+++ b/tests/Command/MigrationRunCommandTest.php
@@ -9,6 +9,7 @@ use ShipMonk\Doctrine\Migration\MigrationRun;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Tester\CommandTester;
 use const PHP_EOL;
 
 class MigrationRunCommandTest extends TestCase
@@ -70,6 +71,14 @@ class MigrationRunCommandTest extends TestCase
             . 'Executing migration version2 phase after... done, 0.000 s elapsed.' . PHP_EOL;
 
         self::assertSame($output, $this->runPhase($command, MigrationRunCommand::PHASE_BOTH));
+    }
+
+    public function testFailureNoArgs(): void
+    {
+        self::expectExceptionMessage('Not enough arguments (missing: "phase").');
+
+        $tester = new CommandTester(new MigrationRunCommand($this->createMock(MigrationService::class)));
+        $tester->execute([]);
     }
 
     private function runPhase(MigrationRunCommand $command, string $phase): string


### PR DESCRIPTION
Otherwise, `Input::validate` is never called and e.g. required arguments are not validated.