### PR TITLE
Add support for generating only empty migration

### DIFF
--- a/src/Command/MigrationGenerateCommand.php
+++ b/src/Command/MigrationGenerateCommand.php
@@ -36,6 +36,7 @@ class MigrationGenerateCommand extends Command
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         $isEmptyOnly = (bool) $input->getOption('empty-only');
+
         if (!$isEmptyOnly) {
             $sqls = $this->migrationService->generateDiffSqls();
 

--- a/src/Command/MigrationGenerateCommand.php
+++ b/src/Command/MigrationGenerateCommand.php
@@ -5,6 +5,7 @@ namespace ShipMonk\Doctrine\Migration\Command;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use function count;
 
@@ -29,14 +30,22 @@ class MigrationGenerateCommand extends Command
     protected function configure(): void
     {
         $this->setDescription('Generate migration class');
+        $this->addOption('empty-only', null, InputOption::VALUE_NONE, 'Skips SQL Diff and only produces empty migration file', null);
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        $sqls = $this->migrationService->generateDiffSqls();
+        $isEmptyOnly = (bool) $input->getOption('empty-only');
+        if (!$isEmptyOnly) {
+            $sqls = $this->migrationService->generateDiffSqls();
 
-        if (count($sqls) === 0) {
-            $output->writeln('<comment>No changes found, creating empty migration class...</comment>');
+            if (count($sqls) === 0) {
+                $output->writeln('<comment>No changes found, creating empty migration class...</comment>');
+            }
+        } else {
+            $sqls = [];
+
+            $output->writeln('<comment>Creating empty migration class...</comment>');
         }
 
         $file = $this->migrationService->generateMigrationFile($sqls);

--- a/tests/Command/MigrationGenerateCommandTest.php
+++ b/tests/Command/MigrationGenerateCommandTest.php
@@ -36,4 +36,22 @@ class MigrationGenerateCommandTest extends TestCase
         self::assertSame('Migration version fakeversion was generated' . PHP_EOL, $output->fetch());
     }
 
+    public function testCheckEmpty(): void
+    {
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->expects(self::never())
+            ->method('generateDiffSqls');
+
+        $migrationService->expects(self::once())
+            ->method('generateMigrationFile')
+            ->with([])
+            ->willReturn(new MigrationFile('fakepath', 'fakeversion'));
+
+        $output = new BufferedOutput();
+        $command = new MigrationGenerateCommand($migrationService);
+        $command->run(new ArrayInput(['--empty-only']), $output);
+
+        self::assertSame('Migration version fakeversion was generated' . PHP_EOL, $output->fetch());
+    }
+
 }

--- a/tests/Command/MigrationGenerateCommandTest.php
+++ b/tests/Command/MigrationGenerateCommandTest.php
@@ -49,7 +49,7 @@ class MigrationGenerateCommandTest extends TestCase
 
         $output = new BufferedOutput();
         $command = new MigrationGenerateCommand($migrationService);
-        $command->run(new ArrayInput(['--empty-only']), $output);
+        $command->run(new ArrayInput(['--empty-only' => true]), $output);
 
         self::assertSame('Migration version fakeversion was generated' . PHP_EOL, $output->fetch());
     }

--- a/tests/Command/MigrationGenerateCommandTest.php
+++ b/tests/Command/MigrationGenerateCommandTest.php
@@ -51,7 +51,7 @@ class MigrationGenerateCommandTest extends TestCase
         $command = new MigrationGenerateCommand($migrationService);
         $command->run(new ArrayInput(['--empty-only' => true]), $output);
 
-        self::assertSame('Migration version fakeversion was generated' . PHP_EOL, $output->fetch());
+        self::assertSame("Creating empty migration class...\nMigration version fakeversion was generated" . PHP_EOL, $output->fetch());
     }
 
 }


### PR DESCRIPTION
Allows optional generating of empty migration - useful for when no schema change is expected but the user still wants to generate a file for data migration to fill manually.