### PR TITLE
Support for sorting/modifying generated statemens

### DIFF
--- a/src/MigrationDefaultAnalyzer.php
+++ b/src/MigrationDefaultAnalyzer.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+class MigrationDefaultAnalyzer implements MigrationsAnalyzer
+{
+
+    /**
+     * @param list<string|Statement> $statements
+     * @return list<Statement>
+     */
+    public function analyze(array $statements): array
+    {
+        $result = [];
+
+        foreach ($statements as $statement) {
+            if ($statement instanceof Statement) {
+                $result[] = $statement;
+            } else {
+                $result[] = new Statement($statement, MigrationPhase::BEFORE);
+            }
+        }
+
+        return $result;
+    }
+
+}

--- a/src/MigrationsAnalyzer.php
+++ b/src/MigrationsAnalyzer.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+/**
+ * Analyzer can:
+ * - sort statements into before/after phases
+ * - modify statements (e.g. adding comment or algorithm/lock clause)
+ * - add new statements (e.g. turn on/off foreign key checks before/after adding a new FK)
+ *
+ * Analyzer should not:
+ * - drop statements
+ * - reorder statements
+ */
+interface MigrationsAnalyzer
+{
+
+    /**
+     * @param list<string|Statement> $statements
+     * @return list<Statement>
+     */
+    public function analyze(array $statements): array;
+
+}

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+class Statement
+{
+
+    public readonly string $sql;
+
+    /**
+     * @var MigrationPhase::*|null
+     */
+    public readonly ?string $phase;
+
+    /**
+     * @param MigrationPhase::*|null $phase
+     */
+    public function __construct(string $sql, ?string $phase = null)
+    {
+        $this->sql = $sql;
+        $this->phase = $phase;
+    }
+
+}

--- a/src/template/migration.txt
+++ b/src/template/migration.txt
@@ -16,6 +16,7 @@ class Migration%version% implements Migration
 
     public function after(MigrationExecutor $executor): void
     {
+        %statementsAfter%
     }
 
 }

--- a/tests/templates/non-transactional.txt
+++ b/tests/templates/non-transactional.txt
@@ -16,6 +16,7 @@ class Migration%version% implements Migration
 
     public function after(MigrationExecutor $executor): void
     {
+        %statementsAfter%
     }
 
 }

--- a/tests/templates/transactional.txt
+++ b/tests/templates/transactional.txt
@@ -17,6 +17,7 @@ class Migration%version% implements Migration, TransactionalMigration
 
     public function after(MigrationExecutor $executor): void
     {
+        %statementsAfter%
     }
 
 }


### PR DESCRIPTION
- allow user to send sorted before/after statements to MigrationService::generateMigrationFile()
- allow user to supply MigrationAnalyzer to sort/modify statements
- fully BC