### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '8.2', '8.3', '8.4' ]
+                php-version: [ '8.2', '8.3', '8.4', '8.5' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
         steps:
             -


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the CI test matrix

The `composer.json` constraint `^8.2` already allows PHP 8.5, this PR adds it to the CI pipeline to ensure tests pass on PHP 8.5.

## Test plan
- CI will run tests on PHP 8.5 with both `prefer-lowest` and `prefer-stable` dependency versions