### PR TITLE
Refactor commands to use PSR-3 logger with ConsoleLogger fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,9 @@ $ bin/console migration:skip
 
 # example output:
 [info] Starting migration skip
-[info] Found 4 migrations to skip in phase after
+[info] Found 1 migrations to skip in phase after
 [info] Migration 20230214154154 phase after skipped
-[info] Migration 20230214155401 phase after skipped
-[info] Migration 20230215050511 phase after skipped
-[info] Migration 20230217061357 phase after skipped
-[info] Migration skip completed, 4 skipped
+[info] Migration skip completed, 1 skipped
 ```
 
 #### Executing migration:
@@ -186,26 +183,18 @@ $ bin/console migration:run before
 
 # example output:
 [info] Starting migration execution (phase before)
-[info] 3 pending migrations found
+[info] 1 pending migrations found
 [info] Executing migration 20220224045126 phase before
 [info] Migration 20220224045126 phase before executed successfully, 0.032 s elapsed
-[info] Executing migration 20220224081809 phase before
-[info] Migration 20220224081809 phase before executed successfully, 0.019 s elapsed
-[info] Executing migration 20220224114846 phase before
-[info] Migration 20220224114846 phase before executed successfully, 0.015 s elapsed
 [info] Migration execution completed (phase before)
 
 $ bin/console migration:run after
 
 # example output:
 [info] Starting migration execution (phase after)
-[info] 3 pending migrations found
+[info] 1 pending migrations found
 [info] Executing migration 20220224045126 phase after
 [info] Migration 20220224045126 phase after executed successfully, 0.033 s elapsed
-[info] Executing migration 20220224081809 phase after
-[info] Migration 20220224081809 phase after executed successfully, 0.006 s elapsed
-[info] Executing migration 20220224114846 phase after
-[info] Migration 20220224114846 phase after executed successfully, 0 s elapsed
 [info] Migration execution completed (phase after)
 ```
 
@@ -216,15 +205,11 @@ $ bin/console migration:run both
 
 # example output:
 [info] Starting migration execution (phase both)
-[info] 4 pending migrations found
+[info] 2 pending migrations found
 [info] Executing migration 20220224045126 phase before
 [info] Migration 20220224045126 phase before executed successfully, 0.032 s elapsed
 [info] Executing migration 20220224045126 phase after
 [info] Migration 20220224045126 phase after executed successfully, 0.033 s elapsed
-[info] Executing migration 20220224081809 phase before
-[info] Migration 20220224081809 phase before executed successfully, 0.019 s elapsed
-[info] Executing migration 20220224081809 phase after
-[info] Migration 20220224081809 phase after executed successfully, 0.006 s elapsed
 [info] Migration execution completed (phase both)
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The bundle requires `symfony/http-kernel` ^6.4+.
 All commands and services are registered automatically, and `Doctrine\ORM\EntityManagerInterface` is autowired.
 If you register a custom `MigrationExecutor`, `MigrationAnalyzer`, or `MigrationVersionProvider` service, it will be picked up automatically.
 
+All commands accept an optional `Psr\Log\LoggerInterface`. When a logger is available (e.g. via MonologBundle), structured log messages with context are emitted. When no logger is injected, commands fall back to `Symfony\Component\Console\Logger\ConsoleLogger` and write directly to the console output.
+
 <details>
 <summary>Manual service registration (without the bundle)</summary>
 
@@ -85,7 +87,8 @@ After installation, you need to create `migration` table in your database. It is
 $ bin/console migration:init
 
 # example output:
-Creating migration table... done.
+[info] Initializing migration table doctrine_migration
+[info] Migration table doctrine_migration created successfully
 ```
 
 #### Generating new migration:
@@ -99,7 +102,9 @@ When no diff is detected, empty migration class is generated.
 $ bin/console migration:generate
 
 # example output:
-Migration version 20230217063818 was generated
+[info] Starting migration generation
+[info] 1 schema changes detected
+[info] Migration version 20230217063818 generated successfully
 ```
 
 The generated file then looks like this:
@@ -136,19 +141,22 @@ You can check awaiting migrations and entity sync status:
 $ bin/console migration:check
 
 # example success output:
-Phase before fully executed, no awaiting migrations
-Phase after fully executed, no awaiting migrations
-Database is synced with entities, no migration needed.
+[info] Starting migration check
+[info] Phase before fully executed, no awaiting migrations
+[info] Phase after fully executed, no awaiting migrations
+[info] Database is synced with entities, no migration needed
+[info] Migration check completed
 ```
 
 ```bash
 $ bin/console migration:check
 
 # example failure output:
-Phase before fully executed, no awaiting migrations
-Phase after has executed migrations not present in /app/migrations: 20220208123456
-Database is not synced with entities, missing updates:
- > DROP INDEX IDX_9DA1A2026EA0B6CA ON my_table
+[info] Starting migration check
+[info] Phase before fully executed, no awaiting migrations
+[error] Phase after has executed migrations not present in /app/migrations: 20220208123456
+[warning] Database is not synced with entities, 1 missing updates
+[info] Migration check completed
 ```
 
 #### Skipping all migrations:
@@ -160,30 +168,45 @@ This will mark all not executed migrations in all stages as migrated.
 $ bin/console migration:skip
 
 # example output:
-Migration 20230214154154 phase after skipped.
-Migration 20230214155401 phase after skipped.
-Migration 20230215050511 phase after skipped.
-Migration 20230217061357 phase after skipped.
+[info] Starting migration skip
+[info] Found 4 migrations to skip in phase after
+[info] Migration 20230214154154 phase after skipped
+[info] Migration 20230214155401 phase after skipped
+[info] Migration 20230215050511 phase after skipped
+[info] Migration 20230217061357 phase after skipped
+[info] Migration skip completed, 4 skipped
 ```
 
 #### Executing migration:
 
-Execution is performed without any interaction and does not fail nor warn when no migration is present for execution.
+Execution is performed without any interaction and does not fail when no migration is present for execution.
 
 ```bash
 $ bin/console migration:run before
 
 # example output:
-Executing migration 20220224045126 phase before... done, 0.032 s elapsed.
-Executing migration 20220224081809 phase before... done, 0.019 s elapsed.
-Executing migration 20220224114846 phase before... done, 0.015 s elapsed.
+[info] Starting migration execution (phase before)
+[info] 3 pending migrations found
+[info] Executing migration 20220224045126 phase before
+[info] Migration 20220224045126 phase before executed successfully, 0.032 s elapsed
+[info] Executing migration 20220224081809 phase before
+[info] Migration 20220224081809 phase before executed successfully, 0.019 s elapsed
+[info] Executing migration 20220224114846 phase before
+[info] Migration 20220224114846 phase before executed successfully, 0.015 s elapsed
+[info] Migration execution completed (phase before)
 
 $ bin/console migration:run after
 
 # example output:
-Executing migration 20220224045126 phase after... done, 0.033 s elapsed.
-Executing migration 20220224081809 phase after... done, 0.006 s elapsed.
-Executing migration 20220224114846 phase after... done, 0.000 s elapsed.
+[info] Starting migration execution (phase after)
+[info] 3 pending migrations found
+[info] Executing migration 20220224045126 phase after
+[info] Migration 20220224045126 phase after executed successfully, 0.033 s elapsed
+[info] Executing migration 20220224081809 phase after
+[info] Migration 20220224081809 phase after executed successfully, 0.006 s elapsed
+[info] Executing migration 20220224114846 phase after
+[info] Migration 20220224114846 phase after executed successfully, 0 s elapsed
+[info] Migration execution completed (phase after)
 ```
 
 When executing all the migrations (e.g. in test environment) you probably want to achieve one-by-one execution. You can do that by:
@@ -192,10 +215,17 @@ When executing all the migrations (e.g. in test environment) you probably want t
 $ bin/console migration:run both
 
 # example output:
-Executing migration 20220224045126 phase before... done, 0.032 s elapsed.
-Executing migration 20220224045126 phase after... done, 0.033 s elapsed.
-Executing migration 20220224081809 phase before... done, 0.019 s elapsed.
-Executing migration 20220224081809 phase after... done, 0.006 s elapsed.
+[info] Starting migration execution (phase both)
+[info] 4 pending migrations found
+[info] Executing migration 20220224045126 phase before
+[info] Migration 20220224045126 phase before executed successfully, 0.032 s elapsed
+[info] Executing migration 20220224045126 phase after
+[info] Migration 20220224045126 phase after executed successfully, 0.033 s elapsed
+[info] Executing migration 20220224081809 phase before
+[info] Migration 20220224081809 phase before executed successfully, 0.019 s elapsed
+[info] Executing migration 20220224081809 phase after
+[info] Migration 20220224081809 phase after executed successfully, 0.006 s elapsed
+[info] Migration execution completed (phase both)
 ```
 
 ### Advanced usage

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "doctrine/dbal": "^4.3.0",
         "doctrine/orm": "^3.3.3",
         "psr/event-dispatcher": "^1.0",
+        "psr/log": "^3.0",
         "symfony/console": "^5.4.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
     },
     "require-dev": {
@@ -19,7 +20,6 @@
         "phpstan/phpstan-phpunit": "^2.0.6",
         "phpstan/phpstan-strict-rules": "^2.0.4",
         "phpunit/phpunit": "^10.5.62",
-        "psr/log": "^3",
         "shipmonk/coding-standard": "^0.2.0",
         "shipmonk/composer-dependency-analyser": "^1.8.3",
         "shipmonk/dead-code-detector": "^0.15.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "doctrine/dbal": "^4.3.0",
         "doctrine/orm": "^3.3.3",
         "psr/event-dispatcher": "^1.0",
-        "psr/log": "^3.0",
+        "psr/log": "^2.0 || ^3.0",
         "symfony/console": "^5.4.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcc7948670607620cbd025ee9101b835",
+    "content-hash": "223c46ab0f1e3a6d2ccacd28a43d3bc5",
     "packages": [
         {
             "name": "doctrine/collections",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8db406addef6b7f3b58fce42cbd26098",
+    "content-hash": "fcc7948670607620cbd025ee9101b835",
     "packages": [
         {
             "name": "doctrine/collections",

--- a/src/Command/ConsoleLoggerFallbackTrait.php
+++ b/src/Command/ConsoleLoggerFallbackTrait.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration\Command;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait ConsoleLoggerFallbackTrait
+{
+
+    private function createLogger(OutputInterface $output): LoggerInterface
+    {
+        return $this->logger ?? new ConsoleLogger($output, [
+            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
+        ]);
+    }
+
+}

--- a/src/Command/MigrationCheckCommand.php
+++ b/src/Command/MigrationCheckCommand.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\Doctrine\Migration\Command;
 
+use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -9,9 +10,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use function array_diff;
+use function array_values;
 use function count;
-use function implode;
-use const PHP_EOL;
 
 #[AsCommand(self::NAME, description: 'Check if entities are in sync with database and if migrations were executed')]
 class MigrationCheckCommand extends Command
@@ -24,14 +24,12 @@ class MigrationCheckCommand extends Command
     private const EXIT_AWAITING_MIGRATION = 1;
     private const EXIT_OK = 0;
 
-    private MigrationService $migrationService;
-
     public function __construct(
-        MigrationService $migrationService,
+        private readonly MigrationService $migrationService,
+        private readonly LoggerInterface $logger,
     )
     {
         parent::__construct();
-        $this->migrationService = $migrationService;
     }
 
     public function execute(
@@ -39,27 +37,38 @@ class MigrationCheckCommand extends Command
         OutputInterface $output,
     ): int
     {
+        $this->logger->info('Starting migration check');
+
         $exitCode = self::EXIT_OK;
-        $exitCode |= $this->checkMigrationsExecuted($output);
-        $exitCode |= $this->checkEntitiesSyncedWithDatabase($output);
+        $exitCode |= $this->checkMigrationsExecuted();
+        $exitCode |= $this->checkEntitiesSyncedWithDatabase();
+
+        $this->logger->info('Migration check completed', [
+            'exitCode' => $exitCode,
+            'success' => $exitCode === self::EXIT_OK,
+        ]);
 
         return $exitCode;
     }
 
-    private function checkEntitiesSyncedWithDatabase(OutputInterface $output): int
+    private function checkEntitiesSyncedWithDatabase(): int
     {
         $updates = $this->migrationService->generateDiffSqls();
+        $updateCount = count($updates);
 
-        if (count($updates) !== 0) {
-            $output->writeln('<comment>Database is not synced with entities, missing updates:' . PHP_EOL . ' > ' . implode(PHP_EOL . ' > ', $updates) . '</comment>');
+        if ($updateCount !== 0) {
+            $this->logger->warning('Database is not synced with entities', [
+                'missingUpdatesCount' => $updateCount,
+                'missingUpdates' => $updates,
+            ]);
             return self::EXIT_ENTITIES_NOT_SYNCED;
         }
 
-        $output->writeln('<info>Database is synced with entities, no migration needed.</info>');
+        $this->logger->info('Database is synced with entities, no migration needed');
         return self::EXIT_OK;
     }
 
-    private function checkMigrationsExecuted(OutputInterface $output): int
+    private function checkMigrationsExecuted(): int
     {
         $exitCode = self::EXIT_OK;
         $migrationsDir = $this->migrationService->getConfig()->getMigrationsDirectory();
@@ -68,21 +77,32 @@ class MigrationCheckCommand extends Command
             $executed = $this->migrationService->getExecutedVersions($phase);
             $prepared = $this->migrationService->getPreparedVersions();
 
-            $toBeExecuted = array_diff($prepared, $executed);
-            $executedNotPresent = array_diff($executed, $prepared);
+            $toBeExecuted = array_values(array_diff($prepared, $executed));
+            $executedNotPresent = array_values(array_diff($executed, $prepared));
 
             if (count($executedNotPresent) > 0) {
                 $exitCode |= self::EXIT_UNKNOWN_MIGRATION;
-                $output->writeln("<error>Phase $phase->value has executed migrations not present in {$migrationsDir}: " . implode(', ', $executedNotPresent) . '</error>');
+                $this->logger->error('Executed migrations not present in migrations directory', [
+                    'phase' => $phase->value,
+                    'migrationsDirectory' => $migrationsDir,
+                    'unknownMigrations' => $executedNotPresent,
+                    'unknownMigrationsCount' => count($executedNotPresent),
+                ]);
             }
 
             if (count($toBeExecuted) > 0) {
                 $exitCode |= self::EXIT_AWAITING_MIGRATION;
-                $output->writeln("<comment>Phase $phase->value not fully executed, awaiting migrations:" . PHP_EOL . ' > ' . implode(PHP_EOL . ' > ', $toBeExecuted) . '</comment>');
+                $this->logger->warning('Phase not fully executed, migrations awaiting', [
+                    'phase' => $phase->value,
+                    'awaitingMigrations' => $toBeExecuted,
+                    'awaitingMigrationsCount' => count($toBeExecuted),
+                ]);
             }
 
             if (count($executedNotPresent) === 0 && count($toBeExecuted) === 0) {
-                $output->writeln("<info>Phase $phase->value fully executed, no awaiting migrations</info>");
+                $this->logger->info('Phase fully executed, no awaiting migrations', [
+                    'phase' => $phase->value,
+                ]);
             }
         }
 

--- a/src/Command/MigrationCheckCommand.php
+++ b/src/Command/MigrationCheckCommand.php
@@ -3,13 +3,11 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use function array_diff;
 use function array_values;
@@ -19,6 +17,8 @@ use function implode;
 #[AsCommand(self::NAME, description: 'Check if entities are in sync with database and if migrations were executed')]
 class MigrationCheckCommand extends Command
 {
+
+    use ConsoleLoggerFallbackTrait;
 
     public const NAME = 'migration:check';
 
@@ -112,14 +112,6 @@ class MigrationCheckCommand extends Command
         }
 
         return $exitCode;
-    }
-
-    private function createLogger(OutputInterface $output): LoggerInterface
-    {
-        return $this->logger ?? new ConsoleLogger($output, [
-            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
-            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
-        ]);
     }
 
 }

--- a/src/Command/MigrationCheckCommand.php
+++ b/src/Command/MigrationCheckCommand.php
@@ -22,10 +22,10 @@ class MigrationCheckCommand extends Command
 
     public const NAME = 'migration:check';
 
-    private const EXIT_ENTITIES_NOT_SYNCED = 4;
-    private const EXIT_UNKNOWN_MIGRATION = 2;
-    private const EXIT_AWAITING_MIGRATION = 1;
-    private const EXIT_OK = 0;
+    public const EXIT_ENTITIES_NOT_SYNCED = 4;
+    public const EXIT_UNKNOWN_MIGRATION = 2;
+    public const EXIT_AWAITING_MIGRATION = 1;
+    public const EXIT_OK = 0;
 
     public function __construct(
         private readonly MigrationService $migrationService,

--- a/src/Command/MigrationCheckCommand.php
+++ b/src/Command/MigrationCheckCommand.php
@@ -3,15 +3,18 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use function array_diff;
 use function array_values;
 use function count;
+use function implode;
 
 #[AsCommand(self::NAME, description: 'Check if entities are in sync with database and if migrations were executed')]
 class MigrationCheckCommand extends Command
@@ -26,7 +29,7 @@ class MigrationCheckCommand extends Command
 
     public function __construct(
         private readonly MigrationService $migrationService,
-        private readonly LoggerInterface $logger,
+        private readonly ?LoggerInterface $logger = null,
     )
     {
         parent::__construct();
@@ -37,13 +40,15 @@ class MigrationCheckCommand extends Command
         OutputInterface $output,
     ): int
     {
-        $this->logger->info('Starting migration check');
+        $logger = $this->createLogger($output);
+
+        $logger->info('Starting migration check');
 
         $exitCode = self::EXIT_OK;
-        $exitCode |= $this->checkMigrationsExecuted();
-        $exitCode |= $this->checkEntitiesSyncedWithDatabase();
+        $exitCode |= $this->checkMigrationsExecuted($logger);
+        $exitCode |= $this->checkEntitiesSyncedWithDatabase($logger);
 
-        $this->logger->info('Migration check completed', [
+        $logger->info('Migration check completed', [
             'exitCode' => $exitCode,
             'success' => $exitCode === self::EXIT_OK,
         ]);
@@ -51,24 +56,24 @@ class MigrationCheckCommand extends Command
         return $exitCode;
     }
 
-    private function checkEntitiesSyncedWithDatabase(): int
+    private function checkEntitiesSyncedWithDatabase(LoggerInterface $logger): int
     {
         $updates = $this->migrationService->generateDiffSqls();
         $updateCount = count($updates);
 
         if ($updateCount !== 0) {
-            $this->logger->warning('Database is not synced with entities', [
+            $logger->warning('Database is not synced with entities, {missingUpdatesCount} missing updates', [
                 'missingUpdatesCount' => $updateCount,
                 'missingUpdates' => $updates,
             ]);
             return self::EXIT_ENTITIES_NOT_SYNCED;
         }
 
-        $this->logger->info('Database is synced with entities, no migration needed');
+        $logger->info('Database is synced with entities, no migration needed');
         return self::EXIT_OK;
     }
 
-    private function checkMigrationsExecuted(): int
+    private function checkMigrationsExecuted(LoggerInterface $logger): int
     {
         $exitCode = self::EXIT_OK;
         $migrationsDir = $this->migrationService->getConfig()->getMigrationsDirectory();
@@ -82,31 +87,39 @@ class MigrationCheckCommand extends Command
 
             if (count($executedNotPresent) > 0) {
                 $exitCode |= self::EXIT_UNKNOWN_MIGRATION;
-                $this->logger->error('Executed migrations not present in migrations directory', [
+                $logger->error('Phase {phase} has executed migrations not present in {migrationsDirectory}: {unknownMigrationsList}', [
                     'phase' => $phase->value,
                     'migrationsDirectory' => $migrationsDir,
                     'unknownMigrations' => $executedNotPresent,
-                    'unknownMigrationsCount' => count($executedNotPresent),
+                    'unknownMigrationsList' => implode(', ', $executedNotPresent),
                 ]);
             }
 
             if (count($toBeExecuted) > 0) {
                 $exitCode |= self::EXIT_AWAITING_MIGRATION;
-                $this->logger->warning('Phase not fully executed, migrations awaiting', [
+                $logger->warning('Phase {phase} not fully executed, awaiting migrations: {awaitingMigrationsList}', [
                     'phase' => $phase->value,
                     'awaitingMigrations' => $toBeExecuted,
-                    'awaitingMigrationsCount' => count($toBeExecuted),
+                    'awaitingMigrationsList' => implode(', ', $toBeExecuted),
                 ]);
             }
 
             if (count($executedNotPresent) === 0 && count($toBeExecuted) === 0) {
-                $this->logger->info('Phase fully executed, no awaiting migrations', [
+                $logger->info('Phase {phase} fully executed, no awaiting migrations', [
                     'phase' => $phase->value,
                 ]);
             }
         }
 
         return $exitCode;
+    }
+
+    private function createLogger(OutputInterface $output): LoggerInterface
+    {
+        return $this->logger ?? new ConsoleLogger($output, [
+            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
+        ]);
     }
 
 }

--- a/src/Command/MigrationGenerateCommand.php
+++ b/src/Command/MigrationGenerateCommand.php
@@ -3,10 +3,12 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use function count;
 
@@ -18,7 +20,7 @@ class MigrationGenerateCommand extends Command
 
     public function __construct(
         private readonly MigrationService $migrationService,
-        private readonly LoggerInterface $logger,
+        private readonly ?LoggerInterface $logger = null,
     )
     {
         parent::__construct();
@@ -29,15 +31,20 @@ class MigrationGenerateCommand extends Command
         OutputInterface $output,
     ): int
     {
-        $this->logger->info('Starting migration generation');
+        $logger = $this->logger ?? new ConsoleLogger($output, [
+            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
+        ]);
+
+        $logger->info('Starting migration generation');
 
         $sqls = $this->migrationService->generateDiffSqls();
         $sqlCount = count($sqls);
 
         if ($sqlCount === 0) {
-            $this->logger->notice('No schema changes found, creating empty migration class');
+            $logger->notice('No schema changes found, creating empty migration class');
         } else {
-            $this->logger->info('Schema changes detected', [
+            $logger->info('{sqlCount} schema changes detected', [
                 'sqlCount' => $sqlCount,
                 'sqls' => $sqls,
             ]);
@@ -45,7 +52,7 @@ class MigrationGenerateCommand extends Command
 
         $file = $this->migrationService->generateMigrationFile($sqls);
 
-        $this->logger->info('Migration generated successfully', [
+        $logger->info('Migration version {version} generated successfully', [
             'version' => $file->version,
             'filePath' => $file->filePath,
             'sqlCount' => $sqlCount,

--- a/src/Command/MigrationGenerateCommand.php
+++ b/src/Command/MigrationGenerateCommand.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\Doctrine\Migration\Command;
 
+use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -15,14 +16,12 @@ class MigrationGenerateCommand extends Command
 
     public const NAME = 'migration:generate';
 
-    private MigrationService $migrationService;
-
     public function __construct(
-        MigrationService $migrationService,
+        private readonly MigrationService $migrationService,
+        private readonly LoggerInterface $logger,
     )
     {
         parent::__construct();
-        $this->migrationService = $migrationService;
     }
 
     public function execute(
@@ -30,15 +29,29 @@ class MigrationGenerateCommand extends Command
         OutputInterface $output,
     ): int
     {
-        $sqls = $this->migrationService->generateDiffSqls();
+        $this->logger->info('Starting migration generation');
 
-        if (count($sqls) === 0) {
-            $output->writeln('<comment>No changes found, creating empty migration class...</comment>');
+        $sqls = $this->migrationService->generateDiffSqls();
+        $sqlCount = count($sqls);
+
+        if ($sqlCount === 0) {
+            $this->logger->notice('No schema changes found, creating empty migration class');
+        } else {
+            $this->logger->info('Schema changes detected', [
+                'sqlCount' => $sqlCount,
+                'sqls' => $sqls,
+            ]);
         }
 
         $file = $this->migrationService->generateMigrationFile($sqls);
 
-        $output->writeln("<info>Migration version {$file->version} was generated</info>");
+        $this->logger->info('Migration generated successfully', [
+            'version' => $file->version,
+            'filePath' => $file->filePath,
+            'sqlCount' => $sqlCount,
+            'isEmpty' => $sqlCount === 0,
+        ]);
+
         return 0;
     }
 

--- a/src/Command/MigrationGenerateCommand.php
+++ b/src/Command/MigrationGenerateCommand.php
@@ -3,18 +3,18 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use function count;
 
 #[AsCommand(self::NAME, description: 'Generate migration class')]
 class MigrationGenerateCommand extends Command
 {
+
+    use ConsoleLoggerFallbackTrait;
 
     public const NAME = 'migration:generate';
 
@@ -31,10 +31,7 @@ class MigrationGenerateCommand extends Command
         OutputInterface $output,
     ): int
     {
-        $logger = $this->logger ?? new ConsoleLogger($output, [
-            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
-            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
-        ]);
+        $logger = $this->createLogger($output);
 
         $logger->info('Starting migration generation');
 

--- a/src/Command/MigrationInitCommand.php
+++ b/src/Command/MigrationInitCommand.php
@@ -3,10 +3,12 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(self::NAME, description: 'Create migration table in database')]
@@ -17,7 +19,7 @@ class MigrationInitCommand extends Command
 
     public function __construct(
         private readonly MigrationService $migrationService,
-        private readonly LoggerInterface $logger,
+        private readonly ?LoggerInterface $logger = null,
     )
     {
         parent::__construct();
@@ -28,20 +30,25 @@ class MigrationInitCommand extends Command
         OutputInterface $output,
     ): int
     {
+        $logger = $this->logger ?? new ConsoleLogger($output, [
+            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
+        ]);
+
         $tableName = $this->migrationService->getConfig()->getMigrationTableName();
 
-        $this->logger->info('Initializing migration table', [
+        $logger->info('Initializing migration table {tableName}', [
             'tableName' => $tableName,
         ]);
 
         $initialized = $this->migrationService->initializeMigrationTable();
 
         if ($initialized) {
-            $this->logger->info('Migration table created successfully', [
+            $logger->info('Migration table {tableName} created successfully', [
                 'tableName' => $tableName,
             ]);
         } else {
-            $this->logger->notice('Migration table already exists', [
+            $logger->notice('Migration table {tableName} already exists', [
                 'tableName' => $tableName,
             ]);
         }

--- a/src/Command/MigrationInitCommand.php
+++ b/src/Command/MigrationInitCommand.php
@@ -3,17 +3,17 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(self::NAME, description: 'Create migration table in database')]
 class MigrationInitCommand extends Command
 {
+
+    use ConsoleLoggerFallbackTrait;
 
     public const NAME = 'migration:init';
 
@@ -30,10 +30,7 @@ class MigrationInitCommand extends Command
         OutputInterface $output,
     ): int
     {
-        $logger = $this->logger ?? new ConsoleLogger($output, [
-            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
-            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
-        ]);
+        $logger = $this->createLogger($output);
 
         $tableName = $this->migrationService->getConfig()->getMigrationTableName();
 

--- a/src/Command/MigrationInitCommand.php
+++ b/src/Command/MigrationInitCommand.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\Doctrine\Migration\Command;
 
+use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -14,15 +15,12 @@ class MigrationInitCommand extends Command
 
     public const NAME = 'migration:init';
 
-    private MigrationService $migrationService;
-
     public function __construct(
-        MigrationService $migrationService,
+        private readonly MigrationService $migrationService,
+        private readonly LoggerInterface $logger,
     )
     {
         parent::__construct();
-
-        $this->migrationService = $migrationService;
     }
 
     public function execute(
@@ -30,9 +28,23 @@ class MigrationInitCommand extends Command
         OutputInterface $output,
     ): int
     {
-        $output->write('<comment>Creating migration table... </comment>');
+        $tableName = $this->migrationService->getConfig()->getMigrationTableName();
+
+        $this->logger->info('Initializing migration table', [
+            'tableName' => $tableName,
+        ]);
+
         $initialized = $this->migrationService->initializeMigrationTable();
-        $output->writeln($initialized ? '<info>done.</info>' : '<comment>already exists</comment>');
+
+        if ($initialized) {
+            $this->logger->info('Migration table created successfully', [
+                'tableName' => $tableName,
+            ]);
+        } else {
+            $this->logger->notice('Migration table already exists', [
+                'tableName' => $tableName,
+            ]);
+        }
 
         return 0;
     }

--- a/src/Command/MigrationRunCommand.php
+++ b/src/Command/MigrationRunCommand.php
@@ -4,14 +4,12 @@ namespace ShipMonk\Doctrine\Migration\Command;
 
 use LogicException;
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use function array_map;
 use function count;
@@ -22,6 +20,8 @@ use function round;
 #[AsCommand(self::NAME, description: 'Run all not executed migrations with specified phase')]
 class MigrationRunCommand extends Command
 {
+
+    use ConsoleLoggerFallbackTrait;
 
     public const NAME = 'migration:run';
 
@@ -172,14 +172,6 @@ class MigrationRunCommand extends Command
         }
 
         throw new LogicException('Unexpected phase argument');
-    }
-
-    private function createLogger(OutputInterface $output): LoggerInterface
-    {
-        return $this->logger ?? new ConsoleLogger($output, [
-            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
-            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
-        ]);
     }
 
 }

--- a/src/Command/MigrationRunCommand.php
+++ b/src/Command/MigrationRunCommand.php
@@ -3,6 +3,7 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use LogicException;
+use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -10,10 +11,10 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function array_map;
+use function count;
 use function in_array;
 use function is_string;
-use function round;
-use function sprintf;
 
 #[AsCommand(self::NAME, description: 'Run all not executed migrations with specified phase')]
 class MigrationRunCommand extends Command
@@ -24,15 +25,12 @@ class MigrationRunCommand extends Command
     public const ARGUMENT_PHASE = 'phase';
     public const PHASE_BOTH = 'both';
 
-    private MigrationService $migrationService;
-
     public function __construct(
-        MigrationService $migrationService,
+        private readonly MigrationService $migrationService,
+        private readonly LoggerInterface $logger,
     )
     {
         parent::__construct();
-
-        $this->migrationService = $migrationService;
     }
 
     protected function configure(): void
@@ -55,13 +53,23 @@ class MigrationRunCommand extends Command
             throw new LogicException('Can never happen for required non-array argument');
         }
 
-        $migratedSomething = $this->executeMigrations(
-            $output,
-            $this->getPhasesToRun($phaseArgument),
-        );
+        $phases = $this->getPhasesToRun($phaseArgument);
+
+        $this->logger->info('Starting migration execution', [
+            'phaseArgument' => $phaseArgument,
+            'phases' => array_map(static fn (MigrationPhase $phase): string => $phase->value, $phases),
+        ]);
+
+        $migratedSomething = $this->executeMigrations($phases);
 
         if (!$migratedSomething) {
-            $output->writeln("<comment>No migration executed (phase {$phaseArgument}).</comment>");
+            $this->logger->notice('No migrations to execute', [
+                'phaseArgument' => $phaseArgument,
+            ]);
+        } else {
+            $this->logger->info('Migration execution completed', [
+                'phaseArgument' => $phaseArgument,
+            ]);
         }
 
         return 0;
@@ -70,10 +78,7 @@ class MigrationRunCommand extends Command
     /**
      * @param list<MigrationPhase> $phases
      */
-    private function executeMigrations(
-        OutputInterface $output,
-        array $phases,
-    ): bool
+    private function executeMigrations(array $phases): bool
     {
         $executed = [];
 
@@ -88,13 +93,30 @@ class MigrationRunCommand extends Command
         $preparedVersions = $this->migrationService->getPreparedVersions();
         $migratedSomething = false;
 
+        $pendingMigrations = [];
+
+        foreach ($preparedVersions as $version) {
+            foreach ($phases as $phase) {
+                if (!isset($executed[$phase->value][$version])) {
+                    $pendingMigrations[] = ['version' => $version, 'phase' => $phase->value];
+                }
+            }
+        }
+
+        if (count($pendingMigrations) > 0) {
+            $this->logger->info('Pending migrations found', [
+                'count' => count($pendingMigrations),
+                'migrations' => $pendingMigrations,
+            ]);
+        }
+
         foreach ($preparedVersions as $version) {
             foreach ($phases as $phase) {
                 if (isset($executed[$phase->value][$version])) {
                     continue;
                 }
 
-                $this->executeMigration($output, $version, $phase);
+                $this->executeMigration($version, $phase);
                 $migratedSomething = true;
             }
         }
@@ -103,17 +125,24 @@ class MigrationRunCommand extends Command
     }
 
     private function executeMigration(
-        OutputInterface $output,
         string $version,
         MigrationPhase $phase,
     ): void
     {
-        $output->write("Executing migration {$version} phase {$phase->value}... ");
+        $this->logger->info('Executing migration', [
+            'version' => $version,
+            'phase' => $phase->value,
+        ]);
 
         $run = $this->migrationService->executeMigration($version, $phase);
 
-        $elapsed = sprintf('%.3f', round($run->getDuration(), 3));
-        $output->writeln("<info>done</info>, {$elapsed} s elapsed.");
+        $this->logger->info('Migration executed successfully', [
+            'version' => $version,
+            'phase' => $phase->value,
+            'durationSeconds' => $run->getDuration(),
+            'startedAt' => $run->getStartedAt()->format('Y-m-d H:i:s.u'),
+            'finishedAt' => $run->getFinishedAt()->format('Y-m-d H:i:s.u'),
+        ]);
     }
 
     /**

--- a/src/Command/MigrationRunCommand.php
+++ b/src/Command/MigrationRunCommand.php
@@ -4,17 +4,20 @@ namespace ShipMonk\Doctrine\Migration\Command;
 
 use LogicException;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use function array_map;
 use function count;
 use function in_array;
 use function is_string;
+use function round;
 
 #[AsCommand(self::NAME, description: 'Run all not executed migrations with specified phase')]
 class MigrationRunCommand extends Command
@@ -27,7 +30,7 @@ class MigrationRunCommand extends Command
 
     public function __construct(
         private readonly MigrationService $migrationService,
-        private readonly LoggerInterface $logger,
+        private readonly ?LoggerInterface $logger = null,
     )
     {
         parent::__construct();
@@ -53,21 +56,23 @@ class MigrationRunCommand extends Command
             throw new LogicException('Can never happen for required non-array argument');
         }
 
+        $logger = $this->createLogger($output);
+
         $phases = $this->getPhasesToRun($phaseArgument);
 
-        $this->logger->info('Starting migration execution', [
+        $logger->info('Starting migration execution (phase {phaseArgument})', [
             'phaseArgument' => $phaseArgument,
             'phases' => array_map(static fn (MigrationPhase $phase): string => $phase->value, $phases),
         ]);
 
-        $migratedSomething = $this->executeMigrations($phases);
+        $migratedSomething = $this->executeMigrations($logger, $phases);
 
         if (!$migratedSomething) {
-            $this->logger->notice('No migrations to execute', [
+            $logger->notice('No migrations to execute (phase {phaseArgument})', [
                 'phaseArgument' => $phaseArgument,
             ]);
         } else {
-            $this->logger->info('Migration execution completed', [
+            $logger->info('Migration execution completed (phase {phaseArgument})', [
                 'phaseArgument' => $phaseArgument,
             ]);
         }
@@ -78,7 +83,10 @@ class MigrationRunCommand extends Command
     /**
      * @param list<MigrationPhase> $phases
      */
-    private function executeMigrations(array $phases): bool
+    private function executeMigrations(
+        LoggerInterface $logger,
+        array $phases,
+    ): bool
     {
         $executed = [];
 
@@ -104,7 +112,7 @@ class MigrationRunCommand extends Command
         }
 
         if (count($pendingMigrations) > 0) {
-            $this->logger->info('Pending migrations found', [
+            $logger->info('{count} pending migrations found', [
                 'count' => count($pendingMigrations),
                 'migrations' => $pendingMigrations,
             ]);
@@ -116,7 +124,7 @@ class MigrationRunCommand extends Command
                     continue;
                 }
 
-                $this->executeMigration($version, $phase);
+                $this->executeMigration($logger, $version, $phase);
                 $migratedSomething = true;
             }
         }
@@ -125,21 +133,22 @@ class MigrationRunCommand extends Command
     }
 
     private function executeMigration(
+        LoggerInterface $logger,
         string $version,
         MigrationPhase $phase,
     ): void
     {
-        $this->logger->info('Executing migration', [
+        $logger->info('Executing migration {version} phase {phase}', [
             'version' => $version,
             'phase' => $phase->value,
         ]);
 
         $run = $this->migrationService->executeMigration($version, $phase);
 
-        $this->logger->info('Migration executed successfully', [
+        $logger->info('Migration {version} phase {phase} executed successfully, {durationSeconds} s elapsed', [
             'version' => $version,
             'phase' => $phase->value,
-            'durationSeconds' => $run->getDuration(),
+            'durationSeconds' => round($run->getDuration(), 3),
             'startedAt' => $run->getStartedAt()->format('Y-m-d H:i:s.u'),
             'finishedAt' => $run->getFinishedAt()->format('Y-m-d H:i:s.u'),
         ]);
@@ -163,6 +172,14 @@ class MigrationRunCommand extends Command
         }
 
         throw new LogicException('Unexpected phase argument');
+    }
+
+    private function createLogger(OutputInterface $output): LoggerInterface
+    {
+        return $this->logger ?? new ConsoleLogger($output, [
+            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
+        ]);
     }
 
 }

--- a/src/Command/MigrationSkipCommand.php
+++ b/src/Command/MigrationSkipCommand.php
@@ -4,12 +4,14 @@ namespace ShipMonk\Doctrine\Migration\Command;
 
 use DateTimeImmutable;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationRun;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use function array_diff;
 use function array_values;
@@ -23,7 +25,7 @@ class MigrationSkipCommand extends Command
 
     public function __construct(
         private readonly MigrationService $migrationService,
-        private readonly LoggerInterface $logger,
+        private readonly ?LoggerInterface $logger = null,
     )
     {
         parent::__construct();
@@ -34,7 +36,12 @@ class MigrationSkipCommand extends Command
         OutputInterface $output,
     ): int
     {
-        $this->logger->info('Starting migration skip');
+        $logger = $this->logger ?? new ConsoleLogger($output, [
+            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
+        ]);
+
+        $logger->info('Starting migration skip');
 
         $skippedCount = 0;
         $skippedMigrations = [];
@@ -45,7 +52,7 @@ class MigrationSkipCommand extends Command
             $toSkip = array_values(array_diff($prepared, $executed));
 
             if (count($toSkip) > 0) {
-                $this->logger->info('Found migrations to skip', [
+                $logger->info('Found {count} migrations to skip in phase {phase}', [
                     'phase' => $phase->value,
                     'count' => count($toSkip),
                     'versions' => $toSkip,
@@ -58,7 +65,7 @@ class MigrationSkipCommand extends Command
 
                 $this->migrationService->markMigrationExecuted($run);
 
-                $this->logger->info('Migration skipped', [
+                $logger->info('Migration {version} phase {phase} skipped', [
                     'version' => $version,
                     'phase' => $phase->value,
                     'markedAt' => $now->format('Y-m-d H:i:s.u'),
@@ -70,9 +77,9 @@ class MigrationSkipCommand extends Command
         }
 
         if ($skippedCount === 0) {
-            $this->logger->notice('No migrations to skip');
+            $logger->notice('No migrations to skip');
         } else {
-            $this->logger->info('Migration skip completed', [
+            $logger->info('Migration skip completed, {skippedCount} skipped', [
                 'skippedCount' => $skippedCount,
                 'skippedMigrations' => $skippedMigrations,
             ]);

--- a/src/Command/MigrationSkipCommand.php
+++ b/src/Command/MigrationSkipCommand.php
@@ -3,6 +3,7 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use DateTimeImmutable;
+use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationRun;
 use ShipMonk\Doctrine\Migration\MigrationService;
@@ -11,6 +12,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use function array_diff;
+use function array_values;
+use function count;
 
 #[AsCommand(self::NAME, description: 'Mark all not executed migrations as executed in both phases')]
 class MigrationSkipCommand extends Command
@@ -18,12 +21,12 @@ class MigrationSkipCommand extends Command
 
     public const NAME = 'migration:skip';
 
-    private MigrationService $migrationService;
-
-    public function __construct(MigrationService $migrationService)
+    public function __construct(
+        private readonly MigrationService $migrationService,
+        private readonly LoggerInterface $logger,
+    )
     {
         parent::__construct();
-        $this->migrationService = $migrationService;
     }
 
     public function execute(
@@ -31,24 +34,48 @@ class MigrationSkipCommand extends Command
         OutputInterface $output,
     ): int
     {
-        $skipped = false;
+        $this->logger->info('Starting migration skip');
+
+        $skippedCount = 0;
+        $skippedMigrations = [];
 
         foreach (MigrationPhase::cases() as $phase) {
             $executed = $this->migrationService->getExecutedVersions($phase);
             $prepared = $this->migrationService->getPreparedVersions();
+            $toSkip = array_values(array_diff($prepared, $executed));
 
-            foreach (array_diff($prepared, $executed) as $version) {
+            if (count($toSkip) > 0) {
+                $this->logger->info('Found migrations to skip', [
+                    'phase' => $phase->value,
+                    'count' => count($toSkip),
+                    'versions' => $toSkip,
+                ]);
+            }
+
+            foreach ($toSkip as $version) {
                 $now = new DateTimeImmutable();
                 $run = new MigrationRun($version, $phase, $now, $now);
 
                 $this->migrationService->markMigrationExecuted($run);
-                $output->writeln("Migration {$version} phase {$phase->value} skipped.");
-                $skipped = true;
+
+                $this->logger->info('Migration skipped', [
+                    'version' => $version,
+                    'phase' => $phase->value,
+                    'markedAt' => $now->format('Y-m-d H:i:s.u'),
+                ]);
+
+                $skippedMigrations[] = ['version' => $version, 'phase' => $phase->value];
+                $skippedCount++;
             }
         }
 
-        if (!$skipped) {
-            $output->writeln('No migration skipped.');
+        if ($skippedCount === 0) {
+            $this->logger->notice('No migrations to skip');
+        } else {
+            $this->logger->info('Migration skip completed', [
+                'skippedCount' => $skippedCount,
+                'skippedMigrations' => $skippedMigrations,
+            ]);
         }
 
         return 0;

--- a/src/Command/MigrationSkipCommand.php
+++ b/src/Command/MigrationSkipCommand.php
@@ -4,14 +4,12 @@ namespace ShipMonk\Doctrine\Migration\Command;
 
 use DateTimeImmutable;
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationRun;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use function array_diff;
 use function array_values;
@@ -20,6 +18,8 @@ use function count;
 #[AsCommand(self::NAME, description: 'Mark all not executed migrations as executed in both phases')]
 class MigrationSkipCommand extends Command
 {
+
+    use ConsoleLoggerFallbackTrait;
 
     public const NAME = 'migration:skip';
 
@@ -36,10 +36,7 @@ class MigrationSkipCommand extends Command
         OutputInterface $output,
     ): int
     {
-        $logger = $this->logger ?? new ConsoleLogger($output, [
-            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
-            LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
-        ]);
+        $logger = $this->createLogger($output);
 
         $logger->info('Starting migration skip');
 

--- a/tests/Command/MigrationCheckCommandTest.php
+++ b/tests/Command/MigrationCheckCommandTest.php
@@ -3,12 +3,10 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationConfig;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use function array_column;
 
 class MigrationCheckCommandTest extends TestCase
 {
@@ -35,18 +33,7 @@ class MigrationCheckCommandTest extends TestCase
 
         $migrationService->method('getConfig')->willReturn($config);
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $logCalls = [];
-        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
-        });
-        $logger->method('warning')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'warning', 'message' => $message, 'context' => $context];
-        });
-        $logger->method('error')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'error', 'message' => $message, 'context' => $context];
-        });
+        $logger = new TestLogger();
 
         $output = new BufferedOutput();
         $command = new MigrationCheckCommand($migrationService, $logger);
@@ -54,13 +41,11 @@ class MigrationCheckCommandTest extends TestCase
 
         self::assertSame(5, $exitCode); // EXIT_ENTITIES_NOT_SYNCED | EXIT_AWAITING_MIGRATION
 
-        // Verify logging calls
-        $logMessages = array_column($logCalls, 'message');
-        self::assertContains('Starting migration check', $logMessages);
-        self::assertContains('Phase {phase} fully executed, no awaiting migrations', $logMessages);
-        self::assertContains('Phase {phase} not fully executed, awaiting migrations: {awaitingMigrationsList}', $logMessages);
-        self::assertContains('Database is not synced with entities, {missingUpdatesCount} missing updates', $logMessages);
-        self::assertContains('Migration check completed', $logMessages);
+        self::assertTrue($logger->hasMessage('Starting migration check'));
+        self::assertTrue($logger->hasMessage('Phase {phase} fully executed, no awaiting migrations'));
+        self::assertTrue($logger->hasMessage('Phase {phase} not fully executed, awaiting migrations: {awaitingMigrationsList}'));
+        self::assertTrue($logger->hasMessage('Database is not synced with entities, {missingUpdatesCount} missing updates'));
+        self::assertTrue($logger->hasMessage('Migration check completed'));
     }
 
 }

--- a/tests/Command/MigrationCheckCommandTest.php
+++ b/tests/Command/MigrationCheckCommandTest.php
@@ -39,7 +39,7 @@ class MigrationCheckCommandTest extends TestCase
         $command = new MigrationCheckCommand($migrationService, $logger);
         $exitCode = $command->run(new ArrayInput([]), $output);
 
-        self::assertSame(5, $exitCode); // EXIT_ENTITIES_NOT_SYNCED | EXIT_AWAITING_MIGRATION
+        self::assertSame(MigrationCheckCommand::EXIT_ENTITIES_NOT_SYNCED | MigrationCheckCommand::EXIT_AWAITING_MIGRATION, $exitCode);
 
         self::assertTrue($logger->hasMessage('Starting migration check'));
         self::assertTrue($logger->hasMessage('Phase {phase} fully executed, no awaiting migrations'));

--- a/tests/Command/MigrationCheckCommandTest.php
+++ b/tests/Command/MigrationCheckCommandTest.php
@@ -57,9 +57,9 @@ class MigrationCheckCommandTest extends TestCase
         // Verify logging calls
         $logMessages = array_column($logCalls, 'message');
         self::assertContains('Starting migration check', $logMessages);
-        self::assertContains('Phase fully executed, no awaiting migrations', $logMessages);
-        self::assertContains('Phase not fully executed, migrations awaiting', $logMessages);
-        self::assertContains('Database is not synced with entities', $logMessages);
+        self::assertContains('Phase {phase} fully executed, no awaiting migrations', $logMessages);
+        self::assertContains('Phase {phase} not fully executed, awaiting migrations: {awaitingMigrationsList}', $logMessages);
+        self::assertContains('Database is not synced with entities, {missingUpdatesCount} missing updates', $logMessages);
         self::assertContains('Migration check completed', $logMessages);
     }
 

--- a/tests/Command/MigrationGenerateCommandTest.php
+++ b/tests/Command/MigrationGenerateCommandTest.php
@@ -3,12 +3,10 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationFile;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use function array_column;
 
 class MigrationGenerateCommandTest extends TestCase
 {
@@ -27,13 +25,7 @@ class MigrationGenerateCommandTest extends TestCase
             ->with([$diffSql])
             ->willReturn(new MigrationFile('fakepath', 'fakeversion', 'fakecontent'));
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        /** @var list<array{level: string, message: string, context: array<string, mixed>}> $logCalls */
-        $logCalls = [];
-        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
-        });
+        $logger = new TestLogger();
 
         $output = new BufferedOutput();
         $command = new MigrationGenerateCommand($migrationService, $logger);
@@ -41,22 +33,16 @@ class MigrationGenerateCommandTest extends TestCase
 
         self::assertSame(0, $exitCode);
 
-        // Verify logging calls
-        $logMessages = array_column($logCalls, 'message');
-        self::assertContains('Starting migration generation', $logMessages);
-        self::assertContains('{sqlCount} schema changes detected', $logMessages);
-        self::assertContains('Migration version {version} generated successfully', $logMessages);
+        self::assertTrue($logger->hasMessage('Starting migration generation'));
+        self::assertTrue($logger->hasMessage('{sqlCount} schema changes detected'));
+        self::assertTrue($logger->hasMessage('Migration version {version} generated successfully'));
 
-        // Verify context includes version and file path
-        foreach ($logCalls as $logCall) {
-            if ($logCall['message'] === 'Migration version {version} generated successfully') {
-                self::assertArrayHasKey('version', $logCall['context']);
-                self::assertArrayHasKey('filePath', $logCall['context']);
-                self::assertSame('fakeversion', $logCall['context']['version']);
-                self::assertSame('fakepath', $logCall['context']['filePath']);
-                break;
-            }
-        }
+        $context = $logger->getContextFor('Migration version {version} generated successfully');
+        self::assertIsArray($context);
+        self::assertArrayHasKey('version', $context);
+        self::assertArrayHasKey('filePath', $context);
+        self::assertSame('fakeversion', $context['version']);
+        self::assertSame('fakepath', $context['filePath']);
     }
 
     public function testGenerateEmpty(): void
@@ -71,15 +57,7 @@ class MigrationGenerateCommandTest extends TestCase
             ->with([])
             ->willReturn(new MigrationFile('fakepath', 'fakeversion', ''));
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $logCalls = [];
-        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
-        });
-        $logger->method('notice')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'notice', 'message' => $message, 'context' => $context];
-        });
+        $logger = new TestLogger();
 
         $output = new BufferedOutput();
         $command = new MigrationGenerateCommand($migrationService, $logger);
@@ -87,10 +65,8 @@ class MigrationGenerateCommandTest extends TestCase
 
         self::assertSame(0, $exitCode);
 
-        // Verify logging calls
-        $logMessages = array_column($logCalls, 'message');
-        self::assertContains('No schema changes found, creating empty migration class', $logMessages);
-        self::assertContains('Migration version {version} generated successfully', $logMessages);
+        self::assertTrue($logger->hasMessage('No schema changes found, creating empty migration class'));
+        self::assertTrue($logger->hasMessage('Migration version {version} generated successfully'));
     }
 
 }

--- a/tests/Command/MigrationGenerateCommandTest.php
+++ b/tests/Command/MigrationGenerateCommandTest.php
@@ -3,19 +3,17 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationFile;
 use ShipMonk\Doctrine\Migration\MigrationService;
-use ShipMonk\Doctrine\Migration\WithEntityManagerTestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use const PHP_EOL;
+use function array_column;
 
 class MigrationGenerateCommandTest extends TestCase
 {
 
-    use WithEntityManagerTestCase;
-
-    public function testCheck(): void
+    public function testGenerate(): void
     {
         $diffSql = 'SELECT 1';
 
@@ -29,11 +27,70 @@ class MigrationGenerateCommandTest extends TestCase
             ->with([$diffSql])
             ->willReturn(new MigrationFile('fakepath', 'fakeversion', 'fakecontent'));
 
-        $output = new BufferedOutput();
-        $command = new MigrationGenerateCommand($migrationService);
-        $command->run(new ArrayInput([]), $output);
+        $logger = $this->createMock(LoggerInterface::class);
 
-        self::assertSame('Migration version fakeversion was generated' . PHP_EOL, $output->fetch());
+        /** @var list<array{level: string, message: string, context: array<string, mixed>}> $logCalls */
+        $logCalls = [];
+        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
+            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
+        });
+
+        $output = new BufferedOutput();
+        $command = new MigrationGenerateCommand($migrationService, $logger);
+        $exitCode = $command->run(new ArrayInput([]), $output);
+
+        self::assertSame(0, $exitCode);
+
+        // Verify logging calls
+        $logMessages = array_column($logCalls, 'message');
+        self::assertContains('Starting migration generation', $logMessages);
+        self::assertContains('Schema changes detected', $logMessages);
+        self::assertContains('Migration generated successfully', $logMessages);
+
+        // Verify context includes version and file path
+        foreach ($logCalls as $logCall) {
+            if ($logCall['message'] === 'Migration generated successfully') {
+                self::assertArrayHasKey('version', $logCall['context']);
+                self::assertArrayHasKey('filePath', $logCall['context']);
+                self::assertSame('fakeversion', $logCall['context']['version']);
+                self::assertSame('fakepath', $logCall['context']['filePath']);
+                break;
+            }
+        }
+    }
+
+    public function testGenerateEmpty(): void
+    {
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->expects(self::once())
+            ->method('generateDiffSqls')
+            ->willReturn([]);
+
+        $migrationService->expects(self::once())
+            ->method('generateMigrationFile')
+            ->with([])
+            ->willReturn(new MigrationFile('fakepath', 'fakeversion', ''));
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $logCalls = [];
+        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
+            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
+        });
+        $logger->method('notice')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
+            $logCalls[] = ['level' => 'notice', 'message' => $message, 'context' => $context];
+        });
+
+        $output = new BufferedOutput();
+        $command = new MigrationGenerateCommand($migrationService, $logger);
+        $exitCode = $command->run(new ArrayInput([]), $output);
+
+        self::assertSame(0, $exitCode);
+
+        // Verify logging calls
+        $logMessages = array_column($logCalls, 'message');
+        self::assertContains('No schema changes found, creating empty migration class', $logMessages);
+        self::assertContains('Migration generated successfully', $logMessages);
     }
 
 }

--- a/tests/Command/MigrationGenerateCommandTest.php
+++ b/tests/Command/MigrationGenerateCommandTest.php
@@ -44,12 +44,12 @@ class MigrationGenerateCommandTest extends TestCase
         // Verify logging calls
         $logMessages = array_column($logCalls, 'message');
         self::assertContains('Starting migration generation', $logMessages);
-        self::assertContains('Schema changes detected', $logMessages);
-        self::assertContains('Migration generated successfully', $logMessages);
+        self::assertContains('{sqlCount} schema changes detected', $logMessages);
+        self::assertContains('Migration version {version} generated successfully', $logMessages);
 
         // Verify context includes version and file path
         foreach ($logCalls as $logCall) {
-            if ($logCall['message'] === 'Migration generated successfully') {
+            if ($logCall['message'] === 'Migration version {version} generated successfully') {
                 self::assertArrayHasKey('version', $logCall['context']);
                 self::assertArrayHasKey('filePath', $logCall['context']);
                 self::assertSame('fakeversion', $logCall['context']['version']);
@@ -90,7 +90,7 @@ class MigrationGenerateCommandTest extends TestCase
         // Verify logging calls
         $logMessages = array_column($logCalls, 'message');
         self::assertContains('No schema changes found, creating empty migration class', $logMessages);
-        self::assertContains('Migration generated successfully', $logMessages);
+        self::assertContains('Migration version {version} generated successfully', $logMessages);
     }
 
 }

--- a/tests/Command/MigrationInitCommandTest.php
+++ b/tests/Command/MigrationInitCommandTest.php
@@ -3,26 +3,77 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ShipMonk\Doctrine\Migration\MigrationConfig;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use const PHP_EOL;
+use function array_column;
 
 class MigrationInitCommandTest extends TestCase
 {
 
     public function testInit(): void
     {
+        $config = $this->createMock(MigrationConfig::class);
+        $config->method('getMigrationTableName')->willReturn('migration');
+
         $migrationService = $this->createMock(MigrationService::class);
         $migrationService->expects(self::once())
             ->method('initializeMigrationTable')
             ->willReturn(true);
+        $migrationService->method('getConfig')->willReturn($config);
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $logCalls = [];
+        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
+            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
+        });
 
         $output = new BufferedOutput();
-        $command = new MigrationInitCommand($migrationService);
-        $command->run(new ArrayInput([]), $output);
+        $command = new MigrationInitCommand($migrationService, $logger);
+        $exitCode = $command->run(new ArrayInput([]), $output);
 
-        self::assertSame('Creating migration table... done.' . PHP_EOL, $output->fetch());
+        self::assertSame(0, $exitCode);
+
+        // Verify logging calls
+        $logMessages = array_column($logCalls, 'message');
+        self::assertContains('Initializing migration table', $logMessages);
+        self::assertContains('Migration table created successfully', $logMessages);
+    }
+
+    public function testInitAlreadyExists(): void
+    {
+        $config = $this->createMock(MigrationConfig::class);
+        $config->method('getMigrationTableName')->willReturn('migration');
+
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->expects(self::once())
+            ->method('initializeMigrationTable')
+            ->willReturn(false);
+        $migrationService->method('getConfig')->willReturn($config);
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $logCalls = [];
+        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
+            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
+        });
+        $logger->method('notice')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
+            $logCalls[] = ['level' => 'notice', 'message' => $message, 'context' => $context];
+        });
+
+        $output = new BufferedOutput();
+        $command = new MigrationInitCommand($migrationService, $logger);
+        $exitCode = $command->run(new ArrayInput([]), $output);
+
+        self::assertSame(0, $exitCode);
+
+        // Verify logging calls
+        $logMessages = array_column($logCalls, 'message');
+        self::assertContains('Initializing migration table', $logMessages);
+        self::assertContains('Migration table already exists', $logMessages);
     }
 
 }

--- a/tests/Command/MigrationInitCommandTest.php
+++ b/tests/Command/MigrationInitCommandTest.php
@@ -39,8 +39,8 @@ class MigrationInitCommandTest extends TestCase
 
         // Verify logging calls
         $logMessages = array_column($logCalls, 'message');
-        self::assertContains('Initializing migration table', $logMessages);
-        self::assertContains('Migration table created successfully', $logMessages);
+        self::assertContains('Initializing migration table {tableName}', $logMessages);
+        self::assertContains('Migration table {tableName} created successfully', $logMessages);
     }
 
     public function testInitAlreadyExists(): void
@@ -72,8 +72,8 @@ class MigrationInitCommandTest extends TestCase
 
         // Verify logging calls
         $logMessages = array_column($logCalls, 'message');
-        self::assertContains('Initializing migration table', $logMessages);
-        self::assertContains('Migration table already exists', $logMessages);
+        self::assertContains('Initializing migration table {tableName}', $logMessages);
+        self::assertContains('Migration table {tableName} already exists', $logMessages);
     }
 
 }

--- a/tests/Command/MigrationInitCommandTest.php
+++ b/tests/Command/MigrationInitCommandTest.php
@@ -3,12 +3,10 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationConfig;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use function array_column;
 
 class MigrationInitCommandTest extends TestCase
 {
@@ -24,12 +22,7 @@ class MigrationInitCommandTest extends TestCase
             ->willReturn(true);
         $migrationService->method('getConfig')->willReturn($config);
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $logCalls = [];
-        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
-        });
+        $logger = new TestLogger();
 
         $output = new BufferedOutput();
         $command = new MigrationInitCommand($migrationService, $logger);
@@ -37,10 +30,8 @@ class MigrationInitCommandTest extends TestCase
 
         self::assertSame(0, $exitCode);
 
-        // Verify logging calls
-        $logMessages = array_column($logCalls, 'message');
-        self::assertContains('Initializing migration table {tableName}', $logMessages);
-        self::assertContains('Migration table {tableName} created successfully', $logMessages);
+        self::assertTrue($logger->hasMessage('Initializing migration table {tableName}'));
+        self::assertTrue($logger->hasMessage('Migration table {tableName} created successfully'));
     }
 
     public function testInitAlreadyExists(): void
@@ -54,15 +45,7 @@ class MigrationInitCommandTest extends TestCase
             ->willReturn(false);
         $migrationService->method('getConfig')->willReturn($config);
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $logCalls = [];
-        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
-        });
-        $logger->method('notice')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'notice', 'message' => $message, 'context' => $context];
-        });
+        $logger = new TestLogger();
 
         $output = new BufferedOutput();
         $command = new MigrationInitCommand($migrationService, $logger);
@@ -70,10 +53,8 @@ class MigrationInitCommandTest extends TestCase
 
         self::assertSame(0, $exitCode);
 
-        // Verify logging calls
-        $logMessages = array_column($logCalls, 'message');
-        self::assertContains('Initializing migration table {tableName}', $logMessages);
-        self::assertContains('Migration table {tableName} already exists', $logMessages);
+        self::assertTrue($logger->hasMessage('Initializing migration table {tableName}'));
+        self::assertTrue($logger->hasMessage('Migration table {tableName} already exists'));
     }
 
 }

--- a/tests/Command/MigrationRunCommandTest.php
+++ b/tests/Command/MigrationRunCommandTest.php
@@ -4,14 +4,12 @@ namespace ShipMonk\Doctrine\Migration\Command;
 
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationRun;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
-use function array_column;
 
 class MigrationRunCommandTest extends TestCase
 {
@@ -32,25 +30,16 @@ class MigrationRunCommandTest extends TestCase
             ->with('fakeversion', MigrationPhase::AFTER)
             ->willReturn(new MigrationRun('fakeversion', MigrationPhase::AFTER, new DateTimeImmutable('today 00:00:00'), new DateTimeImmutable('today 00:00:01')));
 
-        $logger = $this->createMock(LoggerInterface::class);
-
+        $logger = new TestLogger();
         $command = new MigrationRunCommand($migrationService, $logger);
-
-        // Test BEFORE phase - no migration executed
-        $beforeLogCalls = [];
-        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$beforeLogCalls): void {
-            $beforeLogCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
-        });
-        $logger->method('notice')->willReturnCallback(static function (string $message, array $context = []) use (&$beforeLogCalls): void {
-            $beforeLogCalls[] = ['level' => 'notice', 'message' => $message, 'context' => $context];
-        });
 
         $exitCode = $this->runPhase($command, MigrationPhase::BEFORE->value);
         self::assertSame(0, $exitCode);
+        self::assertTrue($logger->hasMessage('No migrations to execute (phase {phaseArgument})'));
 
-        // Test AFTER phase - migration executed
         $exitCode = $this->runPhase($command, MigrationPhase::AFTER->value);
         self::assertSame(0, $exitCode);
+        self::assertTrue($logger->hasMessage('Migration {version} phase {phase} executed successfully, {durationSeconds} s elapsed'));
     }
 
     public function testRunBoth(): void
@@ -79,33 +68,24 @@ class MigrationRunCommandTest extends TestCase
                 return $this->createMock(MigrationRun::class);
             });
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $logCalls = [];
-        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
-        });
-
+        $logger = new TestLogger();
         $command = new MigrationRunCommand($migrationService, $logger);
         $exitCode = $this->runPhase($command, MigrationRunCommand::PHASE_BOTH);
 
         self::assertSame(0, $exitCode);
 
-        // Verify logging calls
-        $logMessages = array_column($logCalls, 'message');
-        self::assertContains('Starting migration execution (phase {phaseArgument})', $logMessages);
-        self::assertContains('{count} pending migrations found', $logMessages);
-        self::assertContains('Executing migration {version} phase {phase}', $logMessages);
-        self::assertContains('Migration {version} phase {phase} executed successfully, {durationSeconds} s elapsed', $logMessages);
-        self::assertContains('Migration execution completed (phase {phaseArgument})', $logMessages);
+        self::assertTrue($logger->hasMessage('Starting migration execution (phase {phaseArgument})'));
+        self::assertTrue($logger->hasMessage('{count} pending migrations found'));
+        self::assertTrue($logger->hasMessage('Executing migration {version} phase {phase}'));
+        self::assertTrue($logger->hasMessage('Migration {version} phase {phase} executed successfully, {durationSeconds} s elapsed'));
+        self::assertTrue($logger->hasMessage('Migration execution completed (phase {phaseArgument})'));
     }
 
     public function testFailureNoArgs(): void
     {
         self::expectExceptionMessage('Not enough arguments (missing: "phase").');
 
-        $logger = $this->createMock(LoggerInterface::class);
-        $tester = new CommandTester(new MigrationRunCommand($this->createMock(MigrationService::class), $logger));
+        $tester = new CommandTester(new MigrationRunCommand($this->createMock(MigrationService::class)));
         $tester->execute([]);
     }
 

--- a/tests/Command/MigrationRunCommandTest.php
+++ b/tests/Command/MigrationRunCommandTest.php
@@ -93,11 +93,11 @@ class MigrationRunCommandTest extends TestCase
 
         // Verify logging calls
         $logMessages = array_column($logCalls, 'message');
-        self::assertContains('Starting migration execution', $logMessages);
-        self::assertContains('Pending migrations found', $logMessages);
-        self::assertContains('Executing migration', $logMessages);
-        self::assertContains('Migration executed successfully', $logMessages);
-        self::assertContains('Migration execution completed', $logMessages);
+        self::assertContains('Starting migration execution (phase {phaseArgument})', $logMessages);
+        self::assertContains('{count} pending migrations found', $logMessages);
+        self::assertContains('Executing migration {version} phase {phase}', $logMessages);
+        self::assertContains('Migration {version} phase {phase} executed successfully, {durationSeconds} s elapsed', $logMessages);
+        self::assertContains('Migration execution completed (phase {phaseArgument})', $logMessages);
     }
 
     public function testFailureNoArgs(): void

--- a/tests/Command/MigrationSkipCommandTest.php
+++ b/tests/Command/MigrationSkipCommandTest.php
@@ -3,15 +3,16 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use const PHP_EOL;
+use function array_column;
 
 class MigrationSkipCommandTest extends TestCase
 {
 
-    public function testCheck(): void
+    public function testSkip(): void
     {
         $migrationService = $this->createMock(MigrationService::class);
         $migrationService->expects(self::exactly(2))
@@ -22,11 +23,76 @@ class MigrationSkipCommandTest extends TestCase
             ->method('getPreparedVersions')
             ->willReturn(['fakeversion']);
 
-        $output = new BufferedOutput();
-        $command = new MigrationSkipCommand($migrationService);
-        $command->run(new ArrayInput([]), $output);
+        $migrationService->expects(self::once())
+            ->method('markMigrationExecuted');
 
-        self::assertSame('Migration fakeversion phase after skipped.' . PHP_EOL, $output->fetch());
+        $logger = $this->createMock(LoggerInterface::class);
+
+        /** @var list<array{level: string, message: string, context: array<string, mixed>}> $logCalls */
+        $logCalls = [];
+        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
+            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
+        });
+
+        $output = new BufferedOutput();
+        $command = new MigrationSkipCommand($migrationService, $logger);
+        $exitCode = $command->run(new ArrayInput([]), $output);
+
+        self::assertSame(0, $exitCode);
+
+        // Verify logging calls
+        $logMessages = array_column($logCalls, 'message');
+        self::assertContains('Starting migration skip', $logMessages);
+        self::assertContains('Found migrations to skip', $logMessages);
+        self::assertContains('Migration skipped', $logMessages);
+        self::assertContains('Migration skip completed', $logMessages);
+
+        // Verify context of the skip
+        foreach ($logCalls as $logCall) {
+            if ($logCall['message'] === 'Migration skipped') {
+                self::assertArrayHasKey('version', $logCall['context']);
+                self::assertArrayHasKey('phase', $logCall['context']);
+                self::assertSame('fakeversion', $logCall['context']['version']);
+                self::assertSame('after', $logCall['context']['phase']);
+                break;
+            }
+        }
+    }
+
+    public function testNoMigrationsToSkip(): void
+    {
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->expects(self::exactly(2))
+            ->method('getExecutedVersions')
+            ->willReturn(['fakeversion']);
+
+        $migrationService->expects(self::exactly(2))
+            ->method('getPreparedVersions')
+            ->willReturn(['fakeversion']);
+
+        $migrationService->expects(self::never())
+            ->method('markMigrationExecuted');
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $logCalls = [];
+        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
+            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
+        });
+        $logger->method('notice')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
+            $logCalls[] = ['level' => 'notice', 'message' => $message, 'context' => $context];
+        });
+
+        $output = new BufferedOutput();
+        $command = new MigrationSkipCommand($migrationService, $logger);
+        $exitCode = $command->run(new ArrayInput([]), $output);
+
+        self::assertSame(0, $exitCode);
+
+        // Verify logging calls
+        $logMessages = array_column($logCalls, 'message');
+        self::assertContains('Starting migration skip', $logMessages);
+        self::assertContains('No migrations to skip', $logMessages);
     }
 
 }

--- a/tests/Command/MigrationSkipCommandTest.php
+++ b/tests/Command/MigrationSkipCommandTest.php
@@ -43,13 +43,13 @@ class MigrationSkipCommandTest extends TestCase
         // Verify logging calls
         $logMessages = array_column($logCalls, 'message');
         self::assertContains('Starting migration skip', $logMessages);
-        self::assertContains('Found migrations to skip', $logMessages);
-        self::assertContains('Migration skipped', $logMessages);
-        self::assertContains('Migration skip completed', $logMessages);
+        self::assertContains('Found {count} migrations to skip in phase {phase}', $logMessages);
+        self::assertContains('Migration {version} phase {phase} skipped', $logMessages);
+        self::assertContains('Migration skip completed, {skippedCount} skipped', $logMessages);
 
         // Verify context of the skip
         foreach ($logCalls as $logCall) {
-            if ($logCall['message'] === 'Migration skipped') {
+            if ($logCall['message'] === 'Migration {version} phase {phase} skipped') {
                 self::assertArrayHasKey('version', $logCall['context']);
                 self::assertArrayHasKey('phase', $logCall['context']);
                 self::assertSame('fakeversion', $logCall['context']['version']);

--- a/tests/Command/MigrationSkipCommandTest.php
+++ b/tests/Command/MigrationSkipCommandTest.php
@@ -3,11 +3,9 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationService;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use function array_column;
 
 class MigrationSkipCommandTest extends TestCase
 {
@@ -26,13 +24,7 @@ class MigrationSkipCommandTest extends TestCase
         $migrationService->expects(self::once())
             ->method('markMigrationExecuted');
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        /** @var list<array{level: string, message: string, context: array<string, mixed>}> $logCalls */
-        $logCalls = [];
-        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
-        });
+        $logger = new TestLogger();
 
         $output = new BufferedOutput();
         $command = new MigrationSkipCommand($migrationService, $logger);
@@ -40,23 +32,17 @@ class MigrationSkipCommandTest extends TestCase
 
         self::assertSame(0, $exitCode);
 
-        // Verify logging calls
-        $logMessages = array_column($logCalls, 'message');
-        self::assertContains('Starting migration skip', $logMessages);
-        self::assertContains('Found {count} migrations to skip in phase {phase}', $logMessages);
-        self::assertContains('Migration {version} phase {phase} skipped', $logMessages);
-        self::assertContains('Migration skip completed, {skippedCount} skipped', $logMessages);
+        self::assertTrue($logger->hasMessage('Starting migration skip'));
+        self::assertTrue($logger->hasMessage('Found {count} migrations to skip in phase {phase}'));
+        self::assertTrue($logger->hasMessage('Migration {version} phase {phase} skipped'));
+        self::assertTrue($logger->hasMessage('Migration skip completed, {skippedCount} skipped'));
 
-        // Verify context of the skip
-        foreach ($logCalls as $logCall) {
-            if ($logCall['message'] === 'Migration {version} phase {phase} skipped') {
-                self::assertArrayHasKey('version', $logCall['context']);
-                self::assertArrayHasKey('phase', $logCall['context']);
-                self::assertSame('fakeversion', $logCall['context']['version']);
-                self::assertSame('after', $logCall['context']['phase']);
-                break;
-            }
-        }
+        $context = $logger->getContextFor('Migration {version} phase {phase} skipped');
+        self::assertIsArray($context);
+        self::assertArrayHasKey('version', $context);
+        self::assertArrayHasKey('phase', $context);
+        self::assertSame('fakeversion', $context['version']);
+        self::assertSame('after', $context['phase']);
     }
 
     public function testNoMigrationsToSkip(): void
@@ -73,15 +59,7 @@ class MigrationSkipCommandTest extends TestCase
         $migrationService->expects(self::never())
             ->method('markMigrationExecuted');
 
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $logCalls = [];
-        $logger->method('info')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'info', 'message' => $message, 'context' => $context];
-        });
-        $logger->method('notice')->willReturnCallback(static function (string $message, array $context = []) use (&$logCalls): void {
-            $logCalls[] = ['level' => 'notice', 'message' => $message, 'context' => $context];
-        });
+        $logger = new TestLogger();
 
         $output = new BufferedOutput();
         $command = new MigrationSkipCommand($migrationService, $logger);
@@ -89,10 +67,8 @@ class MigrationSkipCommandTest extends TestCase
 
         self::assertSame(0, $exitCode);
 
-        // Verify logging calls
-        $logMessages = array_column($logCalls, 'message');
-        self::assertContains('Starting migration skip', $logMessages);
-        self::assertContains('No migrations to skip', $logMessages);
+        self::assertTrue($logger->hasMessage('Starting migration skip'));
+        self::assertTrue($logger->hasMessage('No migrations to skip'));
     }
 
 }

--- a/tests/Command/TestLogger.php
+++ b/tests/Command/TestLogger.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration\Command;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+use function array_column;
+use function in_array;
+use function is_string;
+
+class TestLogger extends AbstractLogger
+{
+
+    /**
+     * @var list<array{level: string, message: string, context: array<string, mixed>}>
+     */
+    private array $records = [];
+
+    public function log(
+        mixed $level,
+        string|Stringable $message,
+        array $context = [],
+    ): void
+    {
+        /** @var array<string, mixed> $context */
+        $this->records[] = [
+            'level' => is_string($level) ? $level : '',
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+
+    public function hasMessage(string $message): bool
+    {
+        return in_array($message, array_column($this->records, 'message'), true);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getContextFor(string $message): ?array
+    {
+        foreach ($this->records as $record) {
+            if ($record['message'] === $message) {
+                return $record['context'];
+            }
+        }
+
+        return null;
+    }
+
+}


### PR DESCRIPTION
## Summary

- Replace `$output->writeln()` with `Psr\Log\LoggerInterface` in all 5 migration commands
- Logger is **optional** (`?LoggerInterface $logger = null`) — no BC break
- When no logger is injected, falls back to `ConsoleLogger($output)` with info/notice at normal verbosity
- Messages use PSR-3 `{placeholder}` interpolation so dynamic data shows in both structured and console output
- Add `psr/log ^2.0 || ^3.0` as a production dependency (moved from require-dev)
- Modernize constructors to PHP 8 promoted `readonly` properties
- Make exit code constants public on `MigrationCheckCommand`

## Design

### ConsoleLogger fallback

A shared `ConsoleLoggerFallbackTrait` provides `createLogger(OutputInterface $output)` used by all commands. When a PSR-3 logger is autowired (e.g. via MonologBundle), it gets structured context data. When not — output goes to the console like before.

### Log levels

| Level | Usage |
|-------|-------|
| `info` | Normal operations (start, completion, successful execution) |
| `notice` | Noteworthy but expected situations (no migrations to execute, empty migration, table already exists) |
| `warning` | Issues needing attention (pending migrations, database not synced) |
| `error` | Serious issues (unknown migrations in database) |

### Context data

Each log message includes structured context for observability. Array values (SQL lists, migration lists) are kept in context only — not interpolated into the message to avoid oversized console lines.

## Test plan

- [x] Logger is optional — commands work without injecting one
- [x] Tests use a shared `TestLogger` instead of mock callback boilerplate
- [x] New test cases for edge paths (empty migration, table already exists, no migrations to skip)
- [x] All checks pass (phpstan, phpunit, phpcs, composer-dependency-analyser)
- [x] README examples updated to match new output format