### PR TITLE
Allow Symfony 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "doctrine/dbal": "^4.3.0",
         "doctrine/orm": "^3.3.3",
         "psr/event-dispatcher": "^1.0",
-        "symfony/console": "^5.4.0 || ^6.0.0 || ^7.0.0"
+        "symfony/console": "^5.4.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
     },
     "require-dev": {
         "doctrine/annotations": "^2.0.0",


### PR DESCRIPTION
## Summary
This PR updates the `symfony/console` dependency to allow Symfony 8.x compatibility.

## Changes
- Updated `symfony/console` version constraint from `^5.4.0 || ^6.0.0 || ^7.0.0` to `^5.4.0 || ^6.0.0 || ^7.0.0 || ^8.0.0`

## Motivation
With Symfony 8 released, this change allows the package to be used in projects that have upgraded to Symfony 8.

## Test plan
- Existing tests should continue to pass
- The package should be installable with Symfony 5.4, 6.x, 7.x, and 8.x