### PR TITLE
Add MigrationServiceRegistry for multiple migration namespaces

### DIFF
--- a/src/Bridge/Symfony/TwoPhaseMigrationsBundle.php
+++ b/src/Bridge/Symfony/TwoPhaseMigrationsBundle.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\Doctrine\Migration\Bridge\Symfony;
 
+use LogicException;
 use ShipMonk\Doctrine\Migration\Command\MigrationCheckCommand;
 use ShipMonk\Doctrine\Migration\Command\MigrationGenerateCommand;
 use ShipMonk\Doctrine\Migration\Command\MigrationInitCommand;
@@ -9,10 +10,14 @@ use ShipMonk\Doctrine\Migration\Command\MigrationRunCommand;
 use ShipMonk\Doctrine\Migration\Command\MigrationSkipCommand;
 use ShipMonk\Doctrine\Migration\MigrationConfig;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use function array_key_first;
+use function count;
 use function dirname;
 
 class TwoPhaseMigrationsBundle extends AbstractBundle
@@ -21,6 +26,20 @@ class TwoPhaseMigrationsBundle extends AbstractBundle
     public function configure(DefinitionConfigurator $definition): void
     {
         $definition->rootNode()
+            ->children()
+            ->scalarNode('migrations_dir')->defaultNull()->end()
+            ->scalarNode('migration_table_name')->defaultNull()->end()
+            ->scalarNode('migration_class_namespace')->defaultNull()->end()
+            ->scalarNode('migration_class_prefix')->defaultNull()->end()
+            ->arrayNode('excluded_tables')
+            ->scalarPrototype()->end()
+            ->defaultValue([])
+            ->end()
+            ->scalarNode('template_file_path')->defaultNull()->end()
+            ->scalarNode('template_indent')->defaultNull()->end()
+            ->arrayNode('namespaces')
+            ->useAttributeAsKey('name')
+            ->arrayPrototype()
             ->children()
             ->scalarNode('migrations_dir')->isRequired()->end()
             ->scalarNode('migration_table_name')->defaultNull()->end()
@@ -32,19 +51,15 @@ class TwoPhaseMigrationsBundle extends AbstractBundle
             ->end()
             ->scalarNode('template_file_path')->defaultNull()->end()
             ->scalarNode('template_indent')->defaultNull()->end()
+            ->scalarNode('entity_manager')->defaultNull()->end()
+            ->end()
+            ->end()
+            ->end()
             ->end();
     }
 
     /**
-     * @param array{
-     *     migrations_dir: string,
-     *     migration_table_name: ?string,
-     *     migration_class_namespace: ?string,
-     *     migration_class_prefix: ?string,
-     *     excluded_tables: list<string>,
-     *     template_file_path: ?string,
-     *     template_indent: ?string,
-     * } $config
+     * @param array<string, mixed> $config
      */
     public function loadExtension( // @phpstan-ignore method.childParameterType, method.childParameterType
         array $config,
@@ -54,19 +69,46 @@ class TwoPhaseMigrationsBundle extends AbstractBundle
     {
         $services = $container->services();
 
-        $services->set(MigrationConfig::class)
-            ->args([
-                '$migrationsDir' => $config['migrations_dir'],
-                '$migrationTableName' => $config['migration_table_name'],
-                '$migrationClassNamespace' => $config['migration_class_namespace'],
-                '$migrationClassPrefix' => $config['migration_class_prefix'],
-                '$excludedTables' => $config['excluded_tables'],
-                '$templateFilePath' => $config['template_file_path'],
-                '$templateIndent' => $config['template_indent'],
-            ]);
+        $namespaces = $this->resolveNamespaces($config);
 
-        $services->set(MigrationService::class)
-            ->autowire();
+        $registryArgs = [];
+
+        /** @var array{migrations_dir: string, migration_table_name: ?string, migration_class_namespace: ?string, migration_class_prefix: ?string, excluded_tables: list<string>, template_file_path: ?string, template_indent: ?string, entity_manager: ?string} $nsConfig */
+        foreach ($namespaces as $name => $nsConfig) {
+            $configServiceId = MigrationConfig::class . '.' . $name;
+            $migrationServiceId = MigrationService::class . '.' . $name;
+
+            $services->set($configServiceId, MigrationConfig::class)
+                ->args([
+                    '$migrationsDir' => $nsConfig['migrations_dir'],
+                    '$migrationTableName' => $nsConfig['migration_table_name'],
+                    '$migrationClassNamespace' => $nsConfig['migration_class_namespace'],
+                    '$migrationClassPrefix' => $nsConfig['migration_class_prefix'],
+                    '$excludedTables' => $nsConfig['excluded_tables'],
+                    '$templateFilePath' => $nsConfig['template_file_path'],
+                    '$templateIndent' => $nsConfig['template_indent'],
+                ]);
+
+            $migrationServiceDef = $services->set($migrationServiceId, MigrationService::class)
+                ->autowire()
+                ->arg('$config', new Reference($configServiceId));
+
+            if ($nsConfig['entity_manager'] !== null) {
+                $migrationServiceDef->arg('$entityManager', new Reference('doctrine.orm.' . $nsConfig['entity_manager'] . '_entity_manager'));
+            }
+
+            $registryArgs[$name] = new Reference($migrationServiceId);
+        }
+
+        // Register default aliases for single-namespace backward compat
+        if (count($namespaces) === 1) {
+            $onlyName = array_key_first($namespaces);
+            $services->alias(MigrationConfig::class, MigrationConfig::class . '.' . $onlyName);
+            $services->alias(MigrationService::class, MigrationService::class . '.' . $onlyName);
+        }
+
+        $services->set(MigrationServiceRegistry::class)
+            ->args([$registryArgs]);
 
         $services->set(MigrationInitCommand::class)
             ->autowire()
@@ -87,6 +129,43 @@ class TwoPhaseMigrationsBundle extends AbstractBundle
         $services->set(MigrationGenerateCommand::class)
             ->autowire()
             ->tag('console.command');
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return array<string, array<string, mixed>>
+     */
+    private function resolveNamespaces(array $config): array
+    {
+        $hasNamespaces = isset($config['namespaces']) && $config['namespaces'] !== [];
+        $hasMigrationsDir = ($config['migrations_dir'] ?? null) !== null;
+
+        if ($hasNamespaces && $hasMigrationsDir) {
+            throw new LogicException('Cannot use both "migrations_dir" and "namespaces" at the same time. Use "namespaces" for multiple namespaces.');
+        }
+
+        if (!$hasNamespaces && !$hasMigrationsDir) {
+            throw new LogicException('Either "migrations_dir" (for single namespace) or "namespaces" (for multiple namespaces) must be configured.');
+        }
+
+        // Multi-namespace config
+        if ($hasNamespaces) {
+            return $config['namespaces']; // @phpstan-ignore return.type
+        }
+
+        // Single namespace (backward compat)
+        return [
+            'default' => [
+                'migrations_dir' => $config['migrations_dir'],
+                'migration_table_name' => $config['migration_table_name'] ?? null,
+                'migration_class_namespace' => $config['migration_class_namespace'] ?? null,
+                'migration_class_prefix' => $config['migration_class_prefix'] ?? null,
+                'excluded_tables' => $config['excluded_tables'] ?? [],
+                'template_file_path' => $config['template_file_path'] ?? null,
+                'template_indent' => $config['template_indent'] ?? null,
+                'entity_manager' => null,
+            ],
+        ];
     }
 
     public function getPath(): string

--- a/src/Command/MigrationCheckCommand.php
+++ b/src/Command/MigrationCheckCommand.php
@@ -5,6 +5,7 @@ namespace ShipMonk\Doctrine\Migration\Command;
 use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,6 +20,7 @@ class MigrationCheckCommand extends Command
 {
 
     use ConsoleLoggerFallbackTrait;
+    use MigrationServiceRegistryAwareTrait;
 
     public const NAME = 'migration:check';
 
@@ -28,11 +30,16 @@ class MigrationCheckCommand extends Command
     public const EXIT_OK = 0;
 
     public function __construct(
-        private readonly MigrationService $migrationService,
+        private readonly MigrationServiceRegistry $migrationServiceRegistry,
         private readonly ?LoggerInterface $logger = null,
     )
     {
         parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addNamespaceOption();
     }
 
     public function execute(
@@ -41,12 +48,13 @@ class MigrationCheckCommand extends Command
     ): int
     {
         $logger = $this->createLogger($output);
+        $migrationService = $this->getMigrationService($input);
 
         $logger->info('Starting migration check');
 
         $exitCode = self::EXIT_OK;
-        $exitCode |= $this->checkMigrationsExecuted($logger);
-        $exitCode |= $this->checkEntitiesSyncedWithDatabase($logger);
+        $exitCode |= $this->checkMigrationsExecuted($logger, $migrationService);
+        $exitCode |= $this->checkEntitiesSyncedWithDatabase($logger, $migrationService);
 
         $logger->info('Migration check completed', [
             'exitCode' => $exitCode,
@@ -56,9 +64,12 @@ class MigrationCheckCommand extends Command
         return $exitCode;
     }
 
-    private function checkEntitiesSyncedWithDatabase(LoggerInterface $logger): int
+    private function checkEntitiesSyncedWithDatabase(
+        LoggerInterface $logger,
+        MigrationService $migrationService,
+    ): int
     {
-        $updates = $this->migrationService->generateDiffSqls();
+        $updates = $migrationService->generateDiffSqls();
         $updateCount = count($updates);
 
         if ($updateCount !== 0) {
@@ -73,14 +84,17 @@ class MigrationCheckCommand extends Command
         return self::EXIT_OK;
     }
 
-    private function checkMigrationsExecuted(LoggerInterface $logger): int
+    private function checkMigrationsExecuted(
+        LoggerInterface $logger,
+        MigrationService $migrationService,
+    ): int
     {
         $exitCode = self::EXIT_OK;
-        $migrationsDir = $this->migrationService->getConfig()->getMigrationsDirectory();
+        $migrationsDir = $migrationService->getConfig()->getMigrationsDirectory();
 
         foreach (MigrationPhase::cases() as $phase) {
-            $executed = $this->migrationService->getExecutedVersions($phase);
-            $prepared = $this->migrationService->getPreparedVersions();
+            $executed = $migrationService->getExecutedVersions($phase);
+            $prepared = $migrationService->getPreparedVersions();
 
             $toBeExecuted = array_values(array_diff($prepared, $executed));
             $executedNotPresent = array_values(array_diff($executed, $prepared));

--- a/src/Command/MigrationGenerateCommand.php
+++ b/src/Command/MigrationGenerateCommand.php
@@ -3,7 +3,7 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use Psr\Log\LoggerInterface;
-use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,15 +15,21 @@ class MigrationGenerateCommand extends Command
 {
 
     use ConsoleLoggerFallbackTrait;
+    use MigrationServiceRegistryAwareTrait;
 
     public const NAME = 'migration:generate';
 
     public function __construct(
-        private readonly MigrationService $migrationService,
+        private readonly MigrationServiceRegistry $migrationServiceRegistry,
         private readonly ?LoggerInterface $logger = null,
     )
     {
         parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addNamespaceOption();
     }
 
     public function execute(
@@ -32,10 +38,11 @@ class MigrationGenerateCommand extends Command
     ): int
     {
         $logger = $this->createLogger($output);
+        $migrationService = $this->getMigrationService($input);
 
         $logger->info('Starting migration generation');
 
-        $sqls = $this->migrationService->generateDiffSqls();
+        $sqls = $migrationService->generateDiffSqls();
         $sqlCount = count($sqls);
 
         if ($sqlCount === 0) {
@@ -47,7 +54,7 @@ class MigrationGenerateCommand extends Command
             ]);
         }
 
-        $file = $this->migrationService->generateMigrationFile($sqls);
+        $file = $migrationService->generateMigrationFile($sqls);
 
         $logger->info('Migration version {version} generated successfully', [
             'version' => $file->version,

--- a/src/Command/MigrationInitCommand.php
+++ b/src/Command/MigrationInitCommand.php
@@ -3,7 +3,7 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use Psr\Log\LoggerInterface;
-use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,15 +14,21 @@ class MigrationInitCommand extends Command
 {
 
     use ConsoleLoggerFallbackTrait;
+    use MigrationServiceRegistryAwareTrait;
 
     public const NAME = 'migration:init';
 
     public function __construct(
-        private readonly MigrationService $migrationService,
+        private readonly MigrationServiceRegistry $migrationServiceRegistry,
         private readonly ?LoggerInterface $logger = null,
     )
     {
         parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addNamespaceOption();
     }
 
     public function execute(
@@ -31,14 +37,15 @@ class MigrationInitCommand extends Command
     ): int
     {
         $logger = $this->createLogger($output);
+        $migrationService = $this->getMigrationService($input);
 
-        $tableName = $this->migrationService->getConfig()->getMigrationTableName();
+        $tableName = $migrationService->getConfig()->getMigrationTableName();
 
         $logger->info('Initializing migration table {tableName}', [
             'tableName' => $tableName,
         ]);
 
-        $initialized = $this->migrationService->initializeMigrationTable();
+        $initialized = $migrationService->initializeMigrationTable();
 
         if ($initialized) {
             $logger->info('Migration table {tableName} created successfully', [

--- a/src/Command/MigrationRunCommand.php
+++ b/src/Command/MigrationRunCommand.php
@@ -6,6 +6,7 @@ use LogicException;
 use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -22,6 +23,7 @@ class MigrationRunCommand extends Command
 {
 
     use ConsoleLoggerFallbackTrait;
+    use MigrationServiceRegistryAwareTrait;
 
     public const NAME = 'migration:run';
 
@@ -29,7 +31,7 @@ class MigrationRunCommand extends Command
     public const PHASE_BOTH = 'both';
 
     public function __construct(
-        private readonly MigrationService $migrationService,
+        private readonly MigrationServiceRegistry $migrationServiceRegistry,
         private readonly ?LoggerInterface $logger = null,
     )
     {
@@ -43,6 +45,7 @@ class MigrationRunCommand extends Command
             InputArgument::REQUIRED,
             MigrationPhase::BEFORE->value . '|' . MigrationPhase::AFTER->value . '|' . self::PHASE_BOTH,
         );
+        $this->addNamespaceOption();
     }
 
     public function execute(
@@ -57,6 +60,7 @@ class MigrationRunCommand extends Command
         }
 
         $logger = $this->createLogger($output);
+        $migrationService = $this->getMigrationService($input);
 
         $phases = $this->getPhasesToRun($phaseArgument);
 
@@ -65,7 +69,7 @@ class MigrationRunCommand extends Command
             'phases' => array_map(static fn (MigrationPhase $phase): string => $phase->value, $phases),
         ]);
 
-        $migratedSomething = $this->executeMigrations($logger, $phases);
+        $migratedSomething = $this->executeMigrations($logger, $migrationService, $phases);
 
         if (!$migratedSomething) {
             $logger->notice('No migrations to execute (phase {phaseArgument})', [
@@ -85,20 +89,21 @@ class MigrationRunCommand extends Command
      */
     private function executeMigrations(
         LoggerInterface $logger,
+        MigrationService $migrationService,
         array $phases,
     ): bool
     {
         $executed = [];
 
         if (in_array(MigrationPhase::BEFORE, $phases, true)) {
-            $executed[MigrationPhase::BEFORE->value] = $this->migrationService->getExecutedVersions(MigrationPhase::BEFORE);
+            $executed[MigrationPhase::BEFORE->value] = $migrationService->getExecutedVersions(MigrationPhase::BEFORE);
         }
 
         if (in_array(MigrationPhase::AFTER, $phases, true)) {
-            $executed[MigrationPhase::AFTER->value] = $this->migrationService->getExecutedVersions(MigrationPhase::AFTER);
+            $executed[MigrationPhase::AFTER->value] = $migrationService->getExecutedVersions(MigrationPhase::AFTER);
         }
 
-        $preparedVersions = $this->migrationService->getPreparedVersions();
+        $preparedVersions = $migrationService->getPreparedVersions();
         $migratedSomething = false;
 
         $pendingMigrations = [];
@@ -124,7 +129,7 @@ class MigrationRunCommand extends Command
                     continue;
                 }
 
-                $this->executeMigration($logger, $version, $phase);
+                $this->executeMigration($logger, $migrationService, $version, $phase);
                 $migratedSomething = true;
             }
         }
@@ -134,6 +139,7 @@ class MigrationRunCommand extends Command
 
     private function executeMigration(
         LoggerInterface $logger,
+        MigrationService $migrationService,
         string $version,
         MigrationPhase $phase,
     ): void
@@ -143,7 +149,7 @@ class MigrationRunCommand extends Command
             'phase' => $phase->value,
         ]);
 
-        $run = $this->migrationService->executeMigration($version, $phase);
+        $run = $migrationService->executeMigration($version, $phase);
 
         $logger->info('Migration {version} phase {phase} executed successfully, {durationSeconds} s elapsed', [
             'version' => $version,

--- a/src/Command/MigrationServiceRegistryAwareTrait.php
+++ b/src/Command/MigrationServiceRegistryAwareTrait.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration\Command;
+
+use ShipMonk\Doctrine\Migration\MigrationService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use function is_string;
+
+trait MigrationServiceRegistryAwareTrait
+{
+
+    private function addNamespaceOption(): void
+    {
+        $this->addOption(
+            'namespace',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Migration namespace to use (required when multiple namespaces are configured)',
+        );
+    }
+
+    private function getMigrationService(InputInterface $input): MigrationService
+    {
+        $namespace = $input->getOption('namespace');
+
+        return $this->migrationServiceRegistry->get(
+            is_string($namespace) ? $namespace : null,
+        );
+    }
+
+}

--- a/src/Command/MigrationSkipCommand.php
+++ b/src/Command/MigrationSkipCommand.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationRun;
-use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,15 +20,21 @@ class MigrationSkipCommand extends Command
 {
 
     use ConsoleLoggerFallbackTrait;
+    use MigrationServiceRegistryAwareTrait;
 
     public const NAME = 'migration:skip';
 
     public function __construct(
-        private readonly MigrationService $migrationService,
+        private readonly MigrationServiceRegistry $migrationServiceRegistry,
         private readonly ?LoggerInterface $logger = null,
     )
     {
         parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addNamespaceOption();
     }
 
     public function execute(
@@ -37,6 +43,7 @@ class MigrationSkipCommand extends Command
     ): int
     {
         $logger = $this->createLogger($output);
+        $migrationService = $this->getMigrationService($input);
 
         $logger->info('Starting migration skip');
 
@@ -44,8 +51,8 @@ class MigrationSkipCommand extends Command
         $skippedMigrations = [];
 
         foreach (MigrationPhase::cases() as $phase) {
-            $executed = $this->migrationService->getExecutedVersions($phase);
-            $prepared = $this->migrationService->getPreparedVersions();
+            $executed = $migrationService->getExecutedVersions($phase);
+            $prepared = $migrationService->getPreparedVersions();
             $toSkip = array_values(array_diff($prepared, $executed));
 
             if (count($toSkip) > 0) {
@@ -60,7 +67,7 @@ class MigrationSkipCommand extends Command
                 $now = new DateTimeImmutable();
                 $run = new MigrationRun($version, $phase, $now, $now);
 
-                $this->migrationService->markMigrationExecuted($run);
+                $migrationService->markMigrationExecuted($run);
 
                 $logger->info('Migration {version} phase {phase} skipped', [
                     'version' => $version,

--- a/src/MigrationServiceRegistry.php
+++ b/src/MigrationServiceRegistry.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+use LogicException;
+use function array_keys;
+use function count;
+use function implode;
+use function reset;
+
+class MigrationServiceRegistry
+{
+
+    /**
+     * @var array<string, MigrationService>
+     */
+    private array $services;
+
+    /**
+     * @param array<string, MigrationService> $services
+     */
+    public function __construct(array $services)
+    {
+        if (count($services) === 0) {
+            throw new LogicException('At least one migration service must be registered');
+        }
+
+        $this->services = $services;
+    }
+
+    public function get(?string $namespace = null): MigrationService
+    {
+        if ($namespace === null) {
+            if (count($this->services) === 1) {
+                return reset($this->services);
+            }
+
+            throw new LogicException(
+                'Multiple migration namespaces are registered, you must specify which one to use via --namespace option. '
+                . 'Available namespaces: ' . implode(', ', array_keys($this->services)),
+            );
+        }
+
+        if (!isset($this->services[$namespace])) {
+            throw new LogicException(
+                "Migration namespace '{$namespace}' is not registered. "
+                . 'Available namespaces: ' . implode(', ', array_keys($this->services)),
+            );
+        }
+
+        return $this->services[$namespace];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getNames(): array
+    {
+        return array_keys($this->services);
+    }
+
+    public function isSingleNamespace(): bool
+    {
+        return count($this->services) === 1;
+    }
+
+}

--- a/tests/Bridge/Symfony/TwoPhaseMigrationsBundleTest.php
+++ b/tests/Bridge/Symfony/TwoPhaseMigrationsBundleTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\Doctrine\Migration\Bridge\Symfony;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use ShipMonk\Doctrine\Migration\Command\MigrationCheckCommand;
 use ShipMonk\Doctrine\Migration\Command\MigrationGenerateCommand;
@@ -10,8 +11,8 @@ use ShipMonk\Doctrine\Migration\Command\MigrationRunCommand;
 use ShipMonk\Doctrine\Migration\Command\MigrationSkipCommand;
 use ShipMonk\Doctrine\Migration\MigrationConfig;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -61,10 +62,50 @@ class TwoPhaseMigrationsBundleTest extends TestCase
 
     public function testConfigurationMissingRequired(): void
     {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('migrations_dir');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Either "migrations_dir"');
 
-        $this->processConfiguration([]);
+        $this->loadBundleExtension([]);
+    }
+
+    public function testConfigurationConflictingMigrationsDirAndNamespaces(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot use both');
+
+        $this->loadBundleExtension([
+            'migrations_dir' => __DIR__ . '/../../..',
+            'namespaces' => [
+                'default' => [
+                    'migrations_dir' => __DIR__ . '/../../..',
+                ],
+            ],
+        ]);
+    }
+
+    public function testConfigurationMultipleNamespaces(): void
+    {
+        $config = $this->processConfiguration([
+            'namespaces' => [
+                'default' => [
+                    'migrations_dir' => __DIR__ . '/../../..',
+                ],
+                'analytics' => [
+                    'migrations_dir' => __DIR__ . '/../../..',
+                    'entity_manager' => 'analytics',
+                    'migration_table_name' => 'analytics_migration',
+                ],
+            ],
+        ]);
+
+        self::assertArrayHasKey('namespaces', $config);
+        /** @var array<string, array<string, mixed>> $namespaces */
+        $namespaces = $config['namespaces'];
+        self::assertCount(2, $namespaces);
+        self::assertArrayHasKey('default', $namespaces);
+        self::assertArrayHasKey('analytics', $namespaces);
+        self::assertSame('analytics', $namespaces['analytics']['entity_manager'] ?? null);
+        self::assertSame('analytics_migration', $namespaces['analytics']['migration_table_name'] ?? null);
     }
 
     public function testServicesAreRegistered(): void
@@ -92,25 +133,76 @@ class TwoPhaseMigrationsBundleTest extends TestCase
             'test',
         );
 
-        $bundle->loadExtension($config, $containerConfigurator, $containerBuilder); // @phpstan-ignore argument.type
-
-        self::assertTrue($containerBuilder->hasDefinition(MigrationConfig::class));
-        self::assertTrue($containerBuilder->hasDefinition(MigrationService::class));
+        $bundle->loadExtension($config, $containerConfigurator, $containerBuilder);
+        self::assertTrue($containerBuilder->hasDefinition(MigrationConfig::class . '.default'));
+        self::assertTrue($containerBuilder->hasDefinition(MigrationService::class . '.default'));
+        self::assertTrue($containerBuilder->hasAlias(MigrationConfig::class));
+        self::assertTrue($containerBuilder->hasAlias(MigrationService::class));
+        self::assertTrue($containerBuilder->hasDefinition(MigrationServiceRegistry::class));
         self::assertTrue($containerBuilder->hasDefinition(MigrationInitCommand::class));
         self::assertTrue($containerBuilder->hasDefinition(MigrationRunCommand::class));
         self::assertTrue($containerBuilder->hasDefinition(MigrationSkipCommand::class));
         self::assertTrue($containerBuilder->hasDefinition(MigrationCheckCommand::class));
         self::assertTrue($containerBuilder->hasDefinition(MigrationGenerateCommand::class));
 
-        $migrationConfigDef = $containerBuilder->getDefinition(MigrationConfig::class);
+        $migrationConfigDef = $containerBuilder->getDefinition(MigrationConfig::class . '.default');
         self::assertSame($migrationsDir, $migrationConfigDef->getArgument('$migrationsDir'));
         self::assertNull($migrationConfigDef->getArgument('$migrationTableName'));
 
-        $migrationServiceDef = $containerBuilder->getDefinition(MigrationService::class);
+        $migrationServiceDef = $containerBuilder->getDefinition(MigrationService::class . '.default');
         self::assertTrue($migrationServiceDef->isAutowired());
 
         $commandDef = $containerBuilder->getDefinition(MigrationInitCommand::class);
         self::assertTrue($commandDef->hasTag('console.command'));
+    }
+
+    public function testMultipleNamespacesServicesRegistered(): void
+    {
+        $migrationsDir = dirname(__DIR__, 2) . '/../tmp/bundle-test-migrations';
+
+        if (!is_dir($migrationsDir)) {
+            mkdir($migrationsDir, 0777, true);
+        }
+
+        $bundle = new TwoPhaseMigrationsBundle();
+        $containerBuilder = new ContainerBuilder(new ParameterBag());
+
+        $config = $this->processConfiguration([
+            'namespaces' => [
+                'default' => [
+                    'migrations_dir' => $migrationsDir,
+                ],
+                'analytics' => [
+                    'migrations_dir' => $migrationsDir,
+                    'entity_manager' => 'analytics',
+                ],
+            ],
+        ]);
+
+        $instanceof = [];
+        $containerConfigurator = new ContainerConfigurator(
+            $containerBuilder,
+            new PhpFileLoader($containerBuilder, new FileLocator(__DIR__)),
+            $instanceof,
+            __DIR__,
+            __FILE__,
+            'test',
+        );
+
+        $bundle->loadExtension($config, $containerConfigurator, $containerBuilder);
+        self::assertTrue($containerBuilder->hasDefinition(MigrationConfig::class . '.default'));
+        self::assertTrue($containerBuilder->hasDefinition(MigrationConfig::class . '.analytics'));
+        self::assertTrue($containerBuilder->hasDefinition(MigrationService::class . '.default'));
+        self::assertTrue($containerBuilder->hasDefinition(MigrationService::class . '.analytics'));
+        self::assertTrue($containerBuilder->hasDefinition(MigrationServiceRegistry::class));
+
+        // No aliases when multiple namespaces
+        self::assertFalse($containerBuilder->hasAlias(MigrationConfig::class));
+        self::assertFalse($containerBuilder->hasAlias(MigrationService::class));
+
+        // Analytics service should have entity manager reference
+        $analyticsDef = $containerBuilder->getDefinition(MigrationService::class . '.analytics');
+        self::assertTrue($analyticsDef->isAutowired());
     }
 
     /**
@@ -131,6 +223,28 @@ class TwoPhaseMigrationsBundleTest extends TestCase
         /** @var array<string, mixed> $result */
         $result = $processor->processConfiguration($configuration, [$extension->getAlias() => $config]);
         return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $rawConfig
+     */
+    private function loadBundleExtension(array $rawConfig): void
+    {
+        $bundle = new TwoPhaseMigrationsBundle();
+        $containerBuilder = new ContainerBuilder(new ParameterBag());
+        $config = $this->processConfiguration($rawConfig);
+
+        $instanceof = [];
+        $containerConfigurator = new ContainerConfigurator(
+            $containerBuilder,
+            new PhpFileLoader($containerBuilder, new FileLocator(__DIR__)),
+            $instanceof,
+            __DIR__,
+            __FILE__,
+            'test',
+        );
+
+        $bundle->loadExtension($config, $containerConfigurator, $containerBuilder);
     }
 
 }

--- a/tests/Command/MigrationCheckCommandTest.php
+++ b/tests/Command/MigrationCheckCommandTest.php
@@ -5,6 +5,7 @@ namespace ShipMonk\Doctrine\Migration\Command;
 use PHPUnit\Framework\TestCase;
 use ShipMonk\Doctrine\Migration\MigrationConfig;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -36,7 +37,7 @@ class MigrationCheckCommandTest extends TestCase
         $logger = new TestLogger();
 
         $output = new BufferedOutput();
-        $command = new MigrationCheckCommand($migrationService, $logger);
+        $command = new MigrationCheckCommand(new MigrationServiceRegistry(['default' => $migrationService]), $logger);
         $exitCode = $command->run(new ArrayInput([]), $output);
 
         self::assertSame(MigrationCheckCommand::EXIT_ENTITIES_NOT_SYNCED | MigrationCheckCommand::EXIT_AWAITING_MIGRATION, $exitCode);

--- a/tests/Command/MigrationGenerateCommandTest.php
+++ b/tests/Command/MigrationGenerateCommandTest.php
@@ -5,6 +5,7 @@ namespace ShipMonk\Doctrine\Migration\Command;
 use PHPUnit\Framework\TestCase;
 use ShipMonk\Doctrine\Migration\MigrationFile;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -28,7 +29,7 @@ class MigrationGenerateCommandTest extends TestCase
         $logger = new TestLogger();
 
         $output = new BufferedOutput();
-        $command = new MigrationGenerateCommand($migrationService, $logger);
+        $command = new MigrationGenerateCommand(new MigrationServiceRegistry(['default' => $migrationService]), $logger);
         $exitCode = $command->run(new ArrayInput([]), $output);
 
         self::assertSame(0, $exitCode);
@@ -60,7 +61,7 @@ class MigrationGenerateCommandTest extends TestCase
         $logger = new TestLogger();
 
         $output = new BufferedOutput();
-        $command = new MigrationGenerateCommand($migrationService, $logger);
+        $command = new MigrationGenerateCommand(new MigrationServiceRegistry(['default' => $migrationService]), $logger);
         $exitCode = $command->run(new ArrayInput([]), $output);
 
         self::assertSame(0, $exitCode);

--- a/tests/Command/MigrationInitCommandTest.php
+++ b/tests/Command/MigrationInitCommandTest.php
@@ -5,6 +5,7 @@ namespace ShipMonk\Doctrine\Migration\Command;
 use PHPUnit\Framework\TestCase;
 use ShipMonk\Doctrine\Migration\MigrationConfig;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -25,7 +26,7 @@ class MigrationInitCommandTest extends TestCase
         $logger = new TestLogger();
 
         $output = new BufferedOutput();
-        $command = new MigrationInitCommand($migrationService, $logger);
+        $command = new MigrationInitCommand(new MigrationServiceRegistry(['default' => $migrationService]), $logger);
         $exitCode = $command->run(new ArrayInput([]), $output);
 
         self::assertSame(0, $exitCode);
@@ -48,13 +49,40 @@ class MigrationInitCommandTest extends TestCase
         $logger = new TestLogger();
 
         $output = new BufferedOutput();
-        $command = new MigrationInitCommand($migrationService, $logger);
+        $command = new MigrationInitCommand(new MigrationServiceRegistry(['default' => $migrationService]), $logger);
         $exitCode = $command->run(new ArrayInput([]), $output);
 
         self::assertSame(0, $exitCode);
 
         self::assertTrue($logger->hasMessage('Initializing migration table {tableName}'));
         self::assertTrue($logger->hasMessage('Migration table {tableName} already exists'));
+    }
+
+    public function testInitWithNamespace(): void
+    {
+        $config = $this->createMock(MigrationConfig::class);
+        $config->method('getMigrationTableName')->willReturn('analytics_migration');
+
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->expects(self::once())
+            ->method('initializeMigrationTable')
+            ->willReturn(true);
+        $migrationService->method('getConfig')->willReturn($config);
+
+        $otherService = $this->createMock(MigrationService::class);
+        $otherService->expects(self::never())->method('initializeMigrationTable');
+
+        $registry = new MigrationServiceRegistry([
+            'default' => $otherService,
+            'analytics' => $migrationService,
+        ]);
+
+        $logger = new TestLogger();
+        $command = new MigrationInitCommand($registry, $logger);
+        $exitCode = $command->run(new ArrayInput(['--namespace' => 'analytics'], $command->getDefinition()), new BufferedOutput());
+
+        self::assertSame(0, $exitCode);
+        self::assertTrue($logger->hasMessage('Migration table {tableName} created successfully'));
     }
 
 }

--- a/tests/Command/MigrationRunCommandTest.php
+++ b/tests/Command/MigrationRunCommandTest.php
@@ -3,10 +3,12 @@
 namespace ShipMonk\Doctrine\Migration\Command;
 
 use DateTimeImmutable;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationRun;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -31,7 +33,7 @@ class MigrationRunCommandTest extends TestCase
             ->willReturn(new MigrationRun('fakeversion', MigrationPhase::AFTER, new DateTimeImmutable('today 00:00:00'), new DateTimeImmutable('today 00:00:01')));
 
         $logger = new TestLogger();
-        $command = new MigrationRunCommand($migrationService, $logger);
+        $command = new MigrationRunCommand(new MigrationServiceRegistry(['default' => $migrationService]), $logger);
 
         $exitCode = $this->runPhase($command, MigrationPhase::BEFORE->value);
         self::assertSame(0, $exitCode);
@@ -69,7 +71,7 @@ class MigrationRunCommandTest extends TestCase
             });
 
         $logger = new TestLogger();
-        $command = new MigrationRunCommand($migrationService, $logger);
+        $command = new MigrationRunCommand(new MigrationServiceRegistry(['default' => $migrationService]), $logger);
         $exitCode = $this->runPhase($command, MigrationRunCommand::PHASE_BOTH);
 
         self::assertSame(0, $exitCode);
@@ -85,8 +87,59 @@ class MigrationRunCommandTest extends TestCase
     {
         self::expectExceptionMessage('Not enough arguments (missing: "phase").');
 
-        $tester = new CommandTester(new MigrationRunCommand($this->createMock(MigrationService::class)));
+        $tester = new CommandTester(new MigrationRunCommand(new MigrationServiceRegistry(['default' => $this->createMock(MigrationService::class)])));
         $tester->execute([]);
+    }
+
+    public function testRunWithNamespace(): void
+    {
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->expects(self::once())
+            ->method('getExecutedVersions')
+            ->willReturn([]);
+        $migrationService->expects(self::once())
+            ->method('getPreparedVersions')
+            ->willReturn(['v1' => 'v1']);
+        $migrationService->expects(self::once())
+            ->method('executeMigration')
+            ->willReturn($this->createMock(MigrationRun::class));
+
+        $otherService = $this->createMock(MigrationService::class);
+        $otherService->expects(self::never())->method('executeMigration');
+
+        $registry = new MigrationServiceRegistry([
+            'default' => $otherService,
+            'analytics' => $migrationService,
+        ]);
+
+        $logger = new TestLogger();
+        $command = new MigrationRunCommand($registry, $logger);
+
+        $input = new ArrayInput([
+            MigrationRunCommand::ARGUMENT_PHASE => MigrationPhase::BEFORE->value,
+            '--namespace' => 'analytics',
+        ], $command->getDefinition());
+        $exitCode = $command->run($input, new BufferedOutput());
+
+        self::assertSame(0, $exitCode);
+    }
+
+    public function testRunRequiresNamespaceWhenMultiple(): void
+    {
+        $registry = new MigrationServiceRegistry([
+            'default' => $this->createMock(MigrationService::class),
+            'analytics' => $this->createMock(MigrationService::class),
+        ]);
+
+        $command = new MigrationRunCommand($registry);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Multiple migration namespaces are registered');
+
+        $input = new ArrayInput([
+            MigrationRunCommand::ARGUMENT_PHASE => MigrationPhase::BEFORE->value,
+        ], $command->getDefinition());
+        $command->run($input, new BufferedOutput());
     }
 
     private function runPhase(

--- a/tests/Command/MigrationSkipCommandTest.php
+++ b/tests/Command/MigrationSkipCommandTest.php
@@ -4,6 +4,7 @@ namespace ShipMonk\Doctrine\Migration\Command;
 
 use PHPUnit\Framework\TestCase;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationServiceRegistry;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -27,7 +28,7 @@ class MigrationSkipCommandTest extends TestCase
         $logger = new TestLogger();
 
         $output = new BufferedOutput();
-        $command = new MigrationSkipCommand($migrationService, $logger);
+        $command = new MigrationSkipCommand(new MigrationServiceRegistry(['default' => $migrationService]), $logger);
         $exitCode = $command->run(new ArrayInput([]), $output);
 
         self::assertSame(0, $exitCode);
@@ -62,7 +63,7 @@ class MigrationSkipCommandTest extends TestCase
         $logger = new TestLogger();
 
         $output = new BufferedOutput();
-        $command = new MigrationSkipCommand($migrationService, $logger);
+        $command = new MigrationSkipCommand(new MigrationServiceRegistry(['default' => $migrationService]), $logger);
         $exitCode = $command->run(new ArrayInput([]), $output);
 
         self::assertSame(0, $exitCode);

--- a/tests/MigrationServiceRegistryTest.php
+++ b/tests/MigrationServiceRegistryTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+class MigrationServiceRegistryTest extends TestCase
+{
+
+    public function testSingleNamespaceWithoutExplicitName(): void
+    {
+        $service = $this->createMock(MigrationService::class);
+        $registry = new MigrationServiceRegistry(['default' => $service]);
+
+        self::assertSame($service, $registry->get());
+        self::assertSame($service, $registry->get(null));
+        self::assertSame($service, $registry->get('default'));
+        self::assertTrue($registry->isSingleNamespace());
+        self::assertSame(['default'], $registry->getNames());
+    }
+
+    public function testMultipleNamespacesRequiresExplicitName(): void
+    {
+        $service1 = $this->createMock(MigrationService::class);
+        $service2 = $this->createMock(MigrationService::class);
+        $registry = new MigrationServiceRegistry(['default' => $service1, 'analytics' => $service2]);
+
+        self::assertSame($service1, $registry->get('default'));
+        self::assertSame($service2, $registry->get('analytics'));
+        self::assertFalse($registry->isSingleNamespace());
+        self::assertSame(['default', 'analytics'], $registry->getNames());
+    }
+
+    public function testMultipleNamespacesThrowsWithoutName(): void
+    {
+        $registry = new MigrationServiceRegistry([
+            'default' => $this->createMock(MigrationService::class),
+            'analytics' => $this->createMock(MigrationService::class),
+        ]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Multiple migration namespaces are registered');
+        $this->expectExceptionMessage('default, analytics');
+
+        $registry->get();
+    }
+
+    public function testUnknownNamespace(): void
+    {
+        $registry = new MigrationServiceRegistry([
+            'default' => $this->createMock(MigrationService::class),
+        ]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage("Migration namespace 'unknown' is not registered");
+
+        $registry->get('unknown');
+    }
+
+    public function testEmptyRegistryThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('At least one migration service must be registered');
+
+        new MigrationServiceRegistry([]);
+    }
+
+}


### PR DESCRIPTION
## Summary

Closes #139

- Introduces `MigrationServiceRegistry` that holds named `MigrationService` instances
- All 5 commands accept the registry and gain an optional `--namespace` CLI option
- When only one service is registered, `--namespace` is not needed (backward-compatible CLI)
- Symfony bundle supports both single (flat) and multi-namespace config

### Open questions

- [ ] `--namespace` naming — collides conceptually with `migrationClassNamespace` in config. Candidates: `--name`, `--scope`, `--em`, `--connection`
- [ ] Constructor BC break — commands now require `MigrationServiceRegistry` instead of `MigrationService`. Migration is a one-liner (`new MigrationServiceRegistry(['default' => $service])`) but still a break.

### Symfony bundle config

```yaml
# Single namespace (unchanged, backward compat)
two_phase_migrations:
    migrations_dir: '%kernel.project_dir%/migrations'

# Multiple namespaces (new)
two_phase_migrations:
    namespaces:
        default:
            migrations_dir: '%kernel.project_dir%/migrations'
        analytics:
            migrations_dir: '%kernel.project_dir%/analytics-migrations'
            entity_manager: analytics
```

## Test plan

- [x] All existing tests updated and passing
- [x] New `MigrationServiceRegistryTest` covering: single/multi namespace resolution, error on ambiguous/unknown namespace
- [x] New command tests for `--namespace` option and multi-namespace error
- [x] New bundle tests for multi-namespace config, validation of conflicting/missing config
- [x] PHPStan, coding standard, dependency analysis all clean

Co-Authored-By: Claude Code