### PR TITLE
Prefix all log context keys with `migration`

### DIFF
--- a/src/Command/MigrationCheckCommand.php
+++ b/src/Command/MigrationCheckCommand.php
@@ -62,9 +62,9 @@ class MigrationCheckCommand extends Command
         $updateCount = count($updates);
 
         if ($updateCount !== 0) {
-            $logger->warning('Database is not synced with entities, {missingUpdatesCount} missing updates', [
-                'missingUpdatesCount' => $updateCount,
-                'missingUpdates' => $updates,
+            $logger->warning('Database is not synced with entities, {migrationMissingUpdatesCount} missing updates', [
+                'migrationMissingUpdatesCount' => $updateCount,
+                'migrationMissingUpdates' => $updates,
             ]);
             return self::EXIT_ENTITIES_NOT_SYNCED;
         }
@@ -87,26 +87,26 @@ class MigrationCheckCommand extends Command
 
             if (count($executedNotPresent) > 0) {
                 $exitCode |= self::EXIT_UNKNOWN_MIGRATION;
-                $logger->error('Phase {phase} has executed migrations not present in {migrationsDirectory}: {unknownMigrationsList}', [
-                    'phase' => $phase->value,
-                    'migrationsDirectory' => $migrationsDir,
-                    'unknownMigrations' => $executedNotPresent,
-                    'unknownMigrationsList' => implode(', ', $executedNotPresent),
+                $logger->error('Phase {migrationPhase} has executed migrations not present in {migrationDirectory}: {migrationUnknownList}', [
+                    'migrationPhase' => $phase->value,
+                    'migrationDirectory' => $migrationsDir,
+                    'migrationUnknown' => $executedNotPresent,
+                    'migrationUnknownList' => implode(', ', $executedNotPresent),
                 ]);
             }
 
             if (count($toBeExecuted) > 0) {
                 $exitCode |= self::EXIT_AWAITING_MIGRATION;
-                $logger->warning('Phase {phase} not fully executed, awaiting migrations: {awaitingMigrationsList}', [
-                    'phase' => $phase->value,
-                    'awaitingMigrations' => $toBeExecuted,
-                    'awaitingMigrationsList' => implode(', ', $toBeExecuted),
+                $logger->warning('Phase {migrationPhase} not fully executed, awaiting migrations: {migrationAwaitingList}', [
+                    'migrationPhase' => $phase->value,
+                    'migrationAwaiting' => $toBeExecuted,
+                    'migrationAwaitingList' => implode(', ', $toBeExecuted),
                 ]);
             }
 
             if (count($executedNotPresent) === 0 && count($toBeExecuted) === 0) {
-                $logger->info('Phase {phase} fully executed, no awaiting migrations', [
-                    'phase' => $phase->value,
+                $logger->info('Phase {migrationPhase} fully executed, no awaiting migrations', [
+                    'migrationPhase' => $phase->value,
                 ]);
             }
         }

--- a/src/Command/MigrationGenerateCommand.php
+++ b/src/Command/MigrationGenerateCommand.php
@@ -41,19 +41,19 @@ class MigrationGenerateCommand extends Command
         if ($sqlCount === 0) {
             $logger->notice('No schema changes found, creating empty migration class');
         } else {
-            $logger->info('{sqlCount} schema changes detected', [
-                'sqlCount' => $sqlCount,
-                'sqls' => $sqls,
+            $logger->info('{migrationSqlCount} schema changes detected', [
+                'migrationSqlCount' => $sqlCount,
+                'migrationSqls' => $sqls,
             ]);
         }
 
         $file = $this->migrationService->generateMigrationFile($sqls);
 
-        $logger->info('Migration version {version} generated successfully', [
-            'version' => $file->version,
-            'filePath' => $file->filePath,
-            'sqlCount' => $sqlCount,
-            'isEmpty' => $sqlCount === 0,
+        $logger->info('Migration version {migrationVersion} generated successfully', [
+            'migrationVersion' => $file->version,
+            'migrationFilePath' => $file->filePath,
+            'migrationSqlCount' => $sqlCount,
+            'migrationIsEmpty' => $sqlCount === 0,
         ]);
 
         return 0;

--- a/src/Command/MigrationRunCommand.php
+++ b/src/Command/MigrationRunCommand.php
@@ -60,20 +60,20 @@ class MigrationRunCommand extends Command
 
         $phases = $this->getPhasesToRun($phaseArgument);
 
-        $logger->info('Starting migration execution (phase {phaseArgument})', [
-            'phaseArgument' => $phaseArgument,
-            'phases' => array_map(static fn (MigrationPhase $phase): string => $phase->value, $phases),
+        $logger->info('Starting migration execution (phase {migrationPhaseArgument})', [
+            'migrationPhaseArgument' => $phaseArgument,
+            'migrationPhases' => array_map(static fn (MigrationPhase $phase): string => $phase->value, $phases),
         ]);
 
         $migratedSomething = $this->executeMigrations($logger, $phases);
 
         if (!$migratedSomething) {
-            $logger->notice('No migrations to execute (phase {phaseArgument})', [
-                'phaseArgument' => $phaseArgument,
+            $logger->notice('No migrations to execute (phase {migrationPhaseArgument})', [
+                'migrationPhaseArgument' => $phaseArgument,
             ]);
         } else {
-            $logger->info('Migration execution completed (phase {phaseArgument})', [
-                'phaseArgument' => $phaseArgument,
+            $logger->info('Migration execution completed (phase {migrationPhaseArgument})', [
+                'migrationPhaseArgument' => $phaseArgument,
             ]);
         }
 
@@ -106,15 +106,15 @@ class MigrationRunCommand extends Command
         foreach ($preparedVersions as $version) {
             foreach ($phases as $phase) {
                 if (!isset($executed[$phase->value][$version])) {
-                    $pendingMigrations[] = ['version' => $version, 'phase' => $phase->value];
+                    $pendingMigrations[] = ['migrationVersion' => $version, 'migrationPhase' => $phase->value];
                 }
             }
         }
 
         if (count($pendingMigrations) > 0) {
-            $logger->info('{count} pending migrations found', [
-                'count' => count($pendingMigrations),
-                'migrations' => $pendingMigrations,
+            $logger->info('{migrationPendingCount} pending migrations found', [
+                'migrationPendingCount' => count($pendingMigrations),
+                'migrationPending' => $pendingMigrations,
             ]);
         }
 
@@ -138,19 +138,19 @@ class MigrationRunCommand extends Command
         MigrationPhase $phase,
     ): void
     {
-        $logger->info('Executing migration {version} phase {phase}', [
-            'version' => $version,
-            'phase' => $phase->value,
+        $logger->info('Executing migration {migrationVersion} phase {migrationPhase}', [
+            'migrationVersion' => $version,
+            'migrationPhase' => $phase->value,
         ]);
 
         $run = $this->migrationService->executeMigration($version, $phase);
 
-        $logger->info('Migration {version} phase {phase} executed successfully, {durationSeconds} s elapsed', [
-            'version' => $version,
-            'phase' => $phase->value,
-            'durationSeconds' => round($run->getDuration(), 3),
-            'startedAt' => $run->getStartedAt()->format('Y-m-d H:i:s.u'),
-            'finishedAt' => $run->getFinishedAt()->format('Y-m-d H:i:s.u'),
+        $logger->info('Migration {migrationVersion} phase {migrationPhase} executed successfully, {migrationDurationSeconds} s elapsed', [
+            'migrationVersion' => $version,
+            'migrationPhase' => $phase->value,
+            'migrationDurationSeconds' => round($run->getDuration(), 3),
+            'migrationStartedAt' => $run->getStartedAt()->format('Y-m-d H:i:s.u'),
+            'migrationFinishedAt' => $run->getFinishedAt()->format('Y-m-d H:i:s.u'),
         ]);
     }
 

--- a/src/Command/MigrationSkipCommand.php
+++ b/src/Command/MigrationSkipCommand.php
@@ -49,10 +49,10 @@ class MigrationSkipCommand extends Command
             $toSkip = array_values(array_diff($prepared, $executed));
 
             if (count($toSkip) > 0) {
-                $logger->info('Found {count} migrations to skip in phase {phase}', [
-                    'phase' => $phase->value,
-                    'count' => count($toSkip),
-                    'versions' => $toSkip,
+                $logger->info('Found {migrationSkipCount} migrations to skip in phase {migrationPhase}', [
+                    'migrationPhase' => $phase->value,
+                    'migrationSkipCount' => count($toSkip),
+                    'migrationVersions' => $toSkip,
                 ]);
             }
 
@@ -62,13 +62,13 @@ class MigrationSkipCommand extends Command
 
                 $this->migrationService->markMigrationExecuted($run);
 
-                $logger->info('Migration {version} phase {phase} skipped', [
-                    'version' => $version,
-                    'phase' => $phase->value,
-                    'markedAt' => $now->format('Y-m-d H:i:s.u'),
+                $logger->info('Migration {migrationVersion} phase {migrationPhase} skipped', [
+                    'migrationVersion' => $version,
+                    'migrationPhase' => $phase->value,
+                    'migrationMarkedAt' => $now->format('Y-m-d H:i:s.u'),
                 ]);
 
-                $skippedMigrations[] = ['version' => $version, 'phase' => $phase->value];
+                $skippedMigrations[] = ['migrationVersion' => $version, 'migrationPhase' => $phase->value];
                 $skippedCount++;
             }
         }
@@ -76,9 +76,9 @@ class MigrationSkipCommand extends Command
         if ($skippedCount === 0) {
             $logger->notice('No migrations to skip');
         } else {
-            $logger->info('Migration skip completed, {skippedCount} skipped', [
-                'skippedCount' => $skippedCount,
-                'skippedMigrations' => $skippedMigrations,
+            $logger->info('Migration skip completed, {migrationSkippedCount} skipped', [
+                'migrationSkippedCount' => $skippedCount,
+                'migrationSkipped' => $skippedMigrations,
             ]);
         }
 

--- a/tests/Command/MigrationCheckCommandTest.php
+++ b/tests/Command/MigrationCheckCommandTest.php
@@ -42,9 +42,9 @@ class MigrationCheckCommandTest extends TestCase
         self::assertSame(MigrationCheckCommand::EXIT_ENTITIES_NOT_SYNCED | MigrationCheckCommand::EXIT_AWAITING_MIGRATION, $exitCode);
 
         self::assertTrue($logger->hasMessage('Starting migration check'));
-        self::assertTrue($logger->hasMessage('Phase {phase} fully executed, no awaiting migrations'));
-        self::assertTrue($logger->hasMessage('Phase {phase} not fully executed, awaiting migrations: {awaitingMigrationsList}'));
-        self::assertTrue($logger->hasMessage('Database is not synced with entities, {missingUpdatesCount} missing updates'));
+        self::assertTrue($logger->hasMessage('Phase {migrationPhase} fully executed, no awaiting migrations'));
+        self::assertTrue($logger->hasMessage('Phase {migrationPhase} not fully executed, awaiting migrations: {migrationAwaitingList}'));
+        self::assertTrue($logger->hasMessage('Database is not synced with entities, {migrationMissingUpdatesCount} missing updates'));
         self::assertTrue($logger->hasMessage('Migration check completed'));
     }
 

--- a/tests/Command/MigrationGenerateCommandTest.php
+++ b/tests/Command/MigrationGenerateCommandTest.php
@@ -34,15 +34,15 @@ class MigrationGenerateCommandTest extends TestCase
         self::assertSame(0, $exitCode);
 
         self::assertTrue($logger->hasMessage('Starting migration generation'));
-        self::assertTrue($logger->hasMessage('{sqlCount} schema changes detected'));
-        self::assertTrue($logger->hasMessage('Migration version {version} generated successfully'));
+        self::assertTrue($logger->hasMessage('{migrationSqlCount} schema changes detected'));
+        self::assertTrue($logger->hasMessage('Migration version {migrationVersion} generated successfully'));
 
-        $context = $logger->getContextFor('Migration version {version} generated successfully');
+        $context = $logger->getContextFor('Migration version {migrationVersion} generated successfully');
         self::assertIsArray($context);
-        self::assertArrayHasKey('version', $context);
-        self::assertArrayHasKey('filePath', $context);
-        self::assertSame('fakeversion', $context['version']);
-        self::assertSame('fakepath', $context['filePath']);
+        self::assertArrayHasKey('migrationVersion', $context);
+        self::assertArrayHasKey('migrationFilePath', $context);
+        self::assertSame('fakeversion', $context['migrationVersion']);
+        self::assertSame('fakepath', $context['migrationFilePath']);
     }
 
     public function testGenerateEmpty(): void
@@ -66,7 +66,7 @@ class MigrationGenerateCommandTest extends TestCase
         self::assertSame(0, $exitCode);
 
         self::assertTrue($logger->hasMessage('No schema changes found, creating empty migration class'));
-        self::assertTrue($logger->hasMessage('Migration version {version} generated successfully'));
+        self::assertTrue($logger->hasMessage('Migration version {migrationVersion} generated successfully'));
     }
 
 }

--- a/tests/Command/MigrationRunCommandTest.php
+++ b/tests/Command/MigrationRunCommandTest.php
@@ -35,11 +35,11 @@ class MigrationRunCommandTest extends TestCase
 
         $exitCode = $this->runPhase($command, MigrationPhase::BEFORE->value);
         self::assertSame(0, $exitCode);
-        self::assertTrue($logger->hasMessage('No migrations to execute (phase {phaseArgument})'));
+        self::assertTrue($logger->hasMessage('No migrations to execute (phase {migrationPhaseArgument})'));
 
         $exitCode = $this->runPhase($command, MigrationPhase::AFTER->value);
         self::assertSame(0, $exitCode);
-        self::assertTrue($logger->hasMessage('Migration {version} phase {phase} executed successfully, {durationSeconds} s elapsed'));
+        self::assertTrue($logger->hasMessage('Migration {migrationVersion} phase {migrationPhase} executed successfully, {migrationDurationSeconds} s elapsed'));
     }
 
     public function testRunBoth(): void
@@ -74,11 +74,11 @@ class MigrationRunCommandTest extends TestCase
 
         self::assertSame(0, $exitCode);
 
-        self::assertTrue($logger->hasMessage('Starting migration execution (phase {phaseArgument})'));
-        self::assertTrue($logger->hasMessage('{count} pending migrations found'));
-        self::assertTrue($logger->hasMessage('Executing migration {version} phase {phase}'));
-        self::assertTrue($logger->hasMessage('Migration {version} phase {phase} executed successfully, {durationSeconds} s elapsed'));
-        self::assertTrue($logger->hasMessage('Migration execution completed (phase {phaseArgument})'));
+        self::assertTrue($logger->hasMessage('Starting migration execution (phase {migrationPhaseArgument})'));
+        self::assertTrue($logger->hasMessage('{migrationPendingCount} pending migrations found'));
+        self::assertTrue($logger->hasMessage('Executing migration {migrationVersion} phase {migrationPhase}'));
+        self::assertTrue($logger->hasMessage('Migration {migrationVersion} phase {migrationPhase} executed successfully, {migrationDurationSeconds} s elapsed'));
+        self::assertTrue($logger->hasMessage('Migration execution completed (phase {migrationPhaseArgument})'));
     }
 
     public function testFailureNoArgs(): void

--- a/tests/Command/MigrationSkipCommandTest.php
+++ b/tests/Command/MigrationSkipCommandTest.php
@@ -33,16 +33,16 @@ class MigrationSkipCommandTest extends TestCase
         self::assertSame(0, $exitCode);
 
         self::assertTrue($logger->hasMessage('Starting migration skip'));
-        self::assertTrue($logger->hasMessage('Found {count} migrations to skip in phase {phase}'));
-        self::assertTrue($logger->hasMessage('Migration {version} phase {phase} skipped'));
-        self::assertTrue($logger->hasMessage('Migration skip completed, {skippedCount} skipped'));
+        self::assertTrue($logger->hasMessage('Found {migrationSkipCount} migrations to skip in phase {migrationPhase}'));
+        self::assertTrue($logger->hasMessage('Migration {migrationVersion} phase {migrationPhase} skipped'));
+        self::assertTrue($logger->hasMessage('Migration skip completed, {migrationSkippedCount} skipped'));
 
-        $context = $logger->getContextFor('Migration {version} phase {phase} skipped');
+        $context = $logger->getContextFor('Migration {migrationVersion} phase {migrationPhase} skipped');
         self::assertIsArray($context);
-        self::assertArrayHasKey('version', $context);
-        self::assertArrayHasKey('phase', $context);
-        self::assertSame('fakeversion', $context['version']);
-        self::assertSame('after', $context['phase']);
+        self::assertArrayHasKey('migrationVersion', $context);
+        self::assertArrayHasKey('migrationPhase', $context);
+        self::assertSame('fakeversion', $context['migrationVersion']);
+        self::assertSame('after', $context['migrationPhase']);
     }
 
     public function testNoMigrationsToSkip(): void


### PR DESCRIPTION
## Summary
- Prefixes all PSR-3 log context keys with `migration` (e.g. `version` → `migrationVersion`, `phase` → `migrationPhase`) to avoid collisions with reserved fields in logging backends like Datadog, where `version` gets deconflicted due to overlap with `dd.version`.

## Test plan
- [ ] Verify in Datadog that `migrationVersion` no longer appears under `deconflicted`

Co-Authored-By: Claude Code