### PR TITLE
Make migration:run safe to run repeatedly and in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ two_phase_migrations:
     # excluded_tables: ['my_tmp_table']
     # template_file_path: '%kernel.project_dir%/migrations/my-template.txt'
     # template_indent: "\t\t"
+    # lock_timeout_seconds: 300 # how long migration:run waits for a lock held by a parallel run before failing
 ```
 
 The bundle requires `symfony/http-kernel` ^6.4+.
@@ -74,6 +75,7 @@ services:
         $excludedTables: ['my_tmp_table'] # migration table ($migrationTableName) is always added to excluded tables automatically
         $templateFilePath: "%kernel.project_dir%/migrations/my-template.txt" # customizable according to your coding style
         $templateIndent: "\t\t" # defaults to spaces
+        $lockTimeoutSeconds: 300 # how long migration:run waits for a lock held by a parallel run before failing
 ```
 </details>
 
@@ -82,6 +84,7 @@ services:
 #### Initialization:
 
 After installation, you need to create `migration` table in your database. It is safe to run it even when the table was already initialized.
+When upgrading from `1.x`, running it once also upgrades the existing table to the new schema (it makes `finished_at` nullable, see [Concurrency & execution safety](#concurrency--execution-safety)). Only that single column is altered, so it is safe to run against a populated table.
 
 ```bash
 $ bin/console migration:init
@@ -213,6 +216,41 @@ $ bin/console migration:run both
 [info] Migration execution completed (phase both)
 ```
 
+### Concurrency & execution safety
+
+`migration:run` is designed to be **safe to run multiple times and in parallel** (e.g. during a rolling deployment where several instances may start the command at once). "Safe" here means it will never silently corrupt your database — not that every invocation finishes the work. Two mechanisms provide this:
+
+#### Parallel runs are serialized by a database lock
+
+Before doing anything, `migration:run` acquires a database-level lock, so only one run executes migrations at a time:
+
+- **MySQL / MariaDB** – a named lock via `GET_LOCK()` / `RELEASE_LOCK()`
+- **PostgreSQL** – a session-level advisory lock via `pg_try_advisory_lock()` / `pg_advisory_unlock()`
+- **other platforms (incl. SQLite)** – no-op (SQLite already serializes writers at the filesystem level)
+
+A parallel run waits up to `lock_timeout_seconds` (default `300`) for the lock and then proceeds once the holder finishes. If the timeout is exceeded, it aborts with exit code `2` instead of running concurrently. The lock is bound to the connection session, so it is released automatically if a runner is killed.
+
+#### Interrupted migrations block all further runs until resolved
+
+Each migration is recorded in two steps: a row with `started_at` (and `finished_at = NULL`) is committed **before** the migration body runs, and `finished_at` is set **after** it succeeds. If a runner is killed mid-migration, a `finished_at = NULL` row is left behind. This start marker is intentionally written outside any transaction, so it relies on the connection committing it immediately (autocommit, the Doctrine default); the detection guarantee does not hold for connections configured with `auto_commit: false`.
+
+Because such a migration may be only partially applied, **every subsequent `migration:run` fails loudly** (exit code `1`) instead of re-executing potentially non-idempotent SQL:
+
+```bash
+$ bin/console migration:run before
+
+# example output:
+[info] Starting migration execution (phase before)
+[error] Migration execution aborted, found 1 unfinished migration(s) from a previously interrupted run, manual resolution is required
+```
+
+To recover, inspect the database to determine what the interrupted migration actually applied, then resolve the `finished_at = NULL` row in the migration table manually:
+
+- delete the row to re-run the migration from scratch (only safe if nothing was applied or the migration is idempotent), or
+- set its `finished_at` to mark it as completed (if you verified everything was applied or finished it by hand).
+
+`migration:run` exit codes: `0` success, `1` unfinished migration found (manual resolution required), `2` lock could not be acquired, `3` migration table missing or not upgraded (run `migration:init`). `migration:check` also reports unfinished migrations (and adds `8` to its exit code bitmask).
+
 ### Advanced usage
 
 #### Run custom code for each executed query:
@@ -248,6 +286,8 @@ Migration table has `started_at` and `finished_at` columns with datetime data wi
 But those columns are declared as VARCHARs by default, because there is [no microsecond support in doctrine/dbal](https://github.com/doctrine/dbal/issues/2873) yet.
 That may complicate datetime manipulations (like duration calculation).
 You can adjust the structure to your needs (e.g. use `DATETIME(6)` for MySQL) manually in some migration.
+
+`finished_at` is nullable: a `NULL` value marks a migration that was started but never finished (see [Concurrency & execution safety](#concurrency--execution-safety)).
 
 ```
 +----------------+--------+-----------------------------+---------------------------+

--- a/src/Bridge/Symfony/TwoPhaseMigrationsBundle.php
+++ b/src/Bridge/Symfony/TwoPhaseMigrationsBundle.php
@@ -32,6 +32,7 @@ class TwoPhaseMigrationsBundle extends AbstractBundle
             ->end()
             ->scalarNode('template_file_path')->defaultNull()->end()
             ->scalarNode('template_indent')->defaultNull()->end()
+            ->integerNode('lock_timeout_seconds')->defaultNull()->end()
             ->end();
     }
 
@@ -44,6 +45,7 @@ class TwoPhaseMigrationsBundle extends AbstractBundle
      *     excluded_tables: list<string>,
      *     template_file_path: ?string,
      *     template_indent: ?string,
+     *     lock_timeout_seconds: ?int,
      * } $config
      */
     public function loadExtension( // @phpstan-ignore method.childParameterType, method.childParameterType
@@ -63,6 +65,7 @@ class TwoPhaseMigrationsBundle extends AbstractBundle
                 '$excludedTables' => $config['excluded_tables'],
                 '$templateFilePath' => $config['template_file_path'],
                 '$templateIndent' => $config['template_indent'],
+                '$lockTimeoutSeconds' => $config['lock_timeout_seconds'],
             ]);
 
         $services->set(MigrationService::class)

--- a/src/Command/MigrationCheckCommand.php
+++ b/src/Command/MigrationCheckCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use function array_diff;
+use function array_map;
 use function array_values;
 use function count;
 use function implode;
@@ -22,6 +23,7 @@ class MigrationCheckCommand extends Command
 
     public const NAME = 'migration:check';
 
+    public const EXIT_INCOMPLETE_MIGRATION = 8;
     public const EXIT_ENTITIES_NOT_SYNCED = 4;
     public const EXIT_UNKNOWN_MIGRATION = 2;
     public const EXIT_AWAITING_MIGRATION = 1;
@@ -45,6 +47,7 @@ class MigrationCheckCommand extends Command
         $logger->info('Starting migration check');
 
         $exitCode = self::EXIT_OK;
+        $exitCode |= $this->checkIncompleteMigrations($logger);
         $exitCode |= $this->checkMigrationsExecuted($logger);
         $exitCode |= $this->checkEntitiesSyncedWithDatabase($logger);
 
@@ -54,6 +57,26 @@ class MigrationCheckCommand extends Command
         ]);
 
         return $exitCode;
+    }
+
+    private function checkIncompleteMigrations(LoggerInterface $logger): int
+    {
+        $incomplete = $this->migrationService->getIncompleteMigrations();
+
+        if (count($incomplete) === 0) {
+            return self::EXIT_OK;
+        }
+
+        $logger->error('Found {migrationIncompleteCount} unfinished migration(s) from a previously interrupted run, manual resolution is required: {migrationIncompleteList}', [
+            'migrationIncompleteCount' => count($incomplete),
+            'migrationIncomplete' => $incomplete,
+            'migrationIncompleteList' => implode(', ', array_map(
+                static fn (array $migration): string => $migration['version'] . ' (phase ' . $migration['phase'] . ')',
+                $incomplete,
+            )),
+        ]);
+
+        return self::EXIT_INCOMPLETE_MIGRATION;
     }
 
     private function checkEntitiesSyncedWithDatabase(LoggerInterface $logger): int

--- a/src/Command/MigrationInitCommand.php
+++ b/src/Command/MigrationInitCommand.php
@@ -4,6 +4,7 @@ namespace ShipMonk\Doctrine\Migration\Command;
 
 use Psr\Log\LoggerInterface;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationTableState;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -38,17 +39,19 @@ class MigrationInitCommand extends Command
             'tableName' => $tableName,
         ]);
 
-        $initialized = $this->migrationService->initializeMigrationTable();
+        $state = $this->migrationService->initializeMigrationTable();
 
-        if ($initialized) {
-            $logger->info('Migration table {tableName} created successfully', [
+        match ($state) {
+            MigrationTableState::Created => $logger->info('Migration table {tableName} created successfully', [
                 'tableName' => $tableName,
-            ]);
-        } else {
-            $logger->notice('Migration table {tableName} already exists', [
+            ]),
+            MigrationTableState::Upgraded => $logger->info('Migration table {tableName} upgraded successfully', [
                 'tableName' => $tableName,
-            ]);
-        }
+            ]),
+            MigrationTableState::AlreadyUpToDate => $logger->notice('Migration table {tableName} already exists', [
+                'tableName' => $tableName,
+            ]),
+        };
 
         return 0;
     }

--- a/src/Command/MigrationRunCommand.php
+++ b/src/Command/MigrationRunCommand.php
@@ -4,13 +4,17 @@ namespace ShipMonk\Doctrine\Migration\Command;
 
 use LogicException;
 use Psr\Log\LoggerInterface;
+use ShipMonk\Doctrine\Migration\IncompleteMigrationException;
+use ShipMonk\Doctrine\Migration\MigrationLockException;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationTableNotInitializedException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 use function array_map;
 use function count;
 use function in_array;
@@ -27,6 +31,11 @@ class MigrationRunCommand extends Command
 
     public const ARGUMENT_PHASE = 'phase';
     public const PHASE_BOTH = 'both';
+
+    public const EXIT_OK = 0;
+    public const EXIT_INCOMPLETE_MIGRATION = 1;
+    public const EXIT_LOCK_NOT_ACQUIRED = 2;
+    public const EXIT_TABLE_NOT_INITIALIZED = 3;
 
     public function __construct(
         private readonly MigrationService $migrationService,
@@ -65,19 +74,61 @@ class MigrationRunCommand extends Command
             'migrationPhases' => array_map(static fn (MigrationPhase $phase): string => $phase->value, $phases),
         ]);
 
-        $migratedSomething = $this->executeMigrations($logger, $phases);
+        // serialize the whole run across processes so parallel invocations are safe
+        try {
+            $this->migrationService->acquireLock();
+        } catch (MigrationLockException $e) {
+            $logger->error('Migration execution aborted, could not acquire migration lock within {migrationLockTimeoutSeconds} s (another migration run is probably in progress)', [
+                'migrationPhaseArgument' => $phaseArgument,
+                'migrationLockTimeoutSeconds' => $e->timeoutSeconds,
+            ]);
 
-        if (!$migratedSomething) {
-            $logger->notice('No migrations to execute (phase {migrationPhaseArgument})', [
-                'migrationPhaseArgument' => $phaseArgument,
-            ]);
-        } else {
-            $logger->info('Migration execution completed (phase {migrationPhaseArgument})', [
-                'migrationPhaseArgument' => $phaseArgument,
-            ]);
+            return self::EXIT_LOCK_NOT_ACQUIRED;
         }
 
-        return 0;
+        try {
+            $this->migrationService->assertMigrationTableUpToDate();
+            $this->migrationService->assertNoIncompleteMigrations();
+
+            $migratedSomething = $this->executeMigrations($logger, $phases);
+
+            if (!$migratedSomething) {
+                $logger->notice('No migrations to execute (phase {migrationPhaseArgument})', [
+                    'migrationPhaseArgument' => $phaseArgument,
+                ]);
+            } else {
+                $logger->info('Migration execution completed (phase {migrationPhaseArgument})', [
+                    'migrationPhaseArgument' => $phaseArgument,
+                ]);
+            }
+
+            return self::EXIT_OK;
+        } catch (MigrationTableNotInitializedException $e) {
+            $logger->error('Migration execution aborted, migration table {migrationTableName} is not initialized, run the migration:init command first', [
+                'migrationPhaseArgument' => $phaseArgument,
+                'migrationTableName' => $e->tableName,
+                'migrationError' => $e->getMessage(),
+            ]);
+
+            return self::EXIT_TABLE_NOT_INITIALIZED;
+        } catch (IncompleteMigrationException $e) {
+            $logger->error('Migration execution aborted, found {migrationIncompleteCount} unfinished migration(s) from a previously interrupted run, manual resolution is required', [
+                'migrationPhaseArgument' => $phaseArgument,
+                'migrationIncompleteCount' => count($e->incompleteMigrations),
+                'migrationIncomplete' => $e->incompleteMigrations,
+            ]);
+
+            return self::EXIT_INCOMPLETE_MIGRATION;
+        } finally {
+            // a failed release must not mask the run's outcome; the session lock auto-releases on connection close
+            try {
+                $this->migrationService->releaseLock();
+            } catch (Throwable $e) {
+                $logger->warning('Failed to release the migration lock, it will be released when the database connection is closed ({migrationError})', [
+                    'migrationError' => $e->getMessage(),
+                ]);
+            }
+        }
     }
 
     /**

--- a/src/IncompleteMigrationException.php
+++ b/src/IncompleteMigrationException.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+use RuntimeException;
+
+/**
+ * Thrown when there are migrations that were started but never finished (e.g. the process was killed mid-execution).
+ * Such migrations may be partially applied, therefore all subsequent runs must fail until the state is resolved manually.
+ *
+ * @api
+ */
+class IncompleteMigrationException extends RuntimeException
+{
+
+    /**
+     * @param list<array{version: string, phase: string, startedAt: string}> $incompleteMigrations
+     */
+    public function __construct(
+        public readonly array $incompleteMigrations,
+        string $message,
+    )
+    {
+        parent::__construct($message);
+    }
+
+}

--- a/src/MigrationConfig.php
+++ b/src/MigrationConfig.php
@@ -5,9 +5,12 @@ namespace ShipMonk\Doctrine\Migration;
 use LogicException;
 use function is_dir;
 use function is_file;
+use function max;
 
 class MigrationConfig
 {
+
+    private const DEFAULT_LOCK_TIMEOUT_SECONDS = 300;
 
     private string $migrationsDir;
 
@@ -26,6 +29,8 @@ class MigrationConfig
 
     private string $templateIndent;
 
+    private int $lockTimeoutSeconds;
+
     /**
      * @param string[]|null $excludedTables
      */
@@ -37,6 +42,7 @@ class MigrationConfig
         ?array $excludedTables = null,
         ?string $templateFilePath = null,
         ?string $templateIndent = null,
+        ?int $lockTimeoutSeconds = null,
     )
     {
         $templateFilePathToUse = $templateFilePath ?? __DIR__ . '/template/migration.txt';
@@ -57,6 +63,7 @@ class MigrationConfig
         $this->excludedTables[] = $this->getMigrationTableName();
         $this->templateFilePath = $templateFilePathToUse;
         $this->templateIndent = $templateIndent ?? '        ';
+        $this->lockTimeoutSeconds = max(1, $lockTimeoutSeconds ?? self::DEFAULT_LOCK_TIMEOUT_SECONDS);
     }
 
     public function getMigrationsDirectory(): string
@@ -95,6 +102,11 @@ class MigrationConfig
     public function getTemplateIndent(): string
     {
         return $this->templateIndent;
+    }
+
+    public function getLockTimeoutSeconds(): int
+    {
+        return $this->lockTimeoutSeconds;
     }
 
 }

--- a/src/MigrationLock.php
+++ b/src/MigrationLock.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use function crc32;
+use function microtime;
+use function min;
+use function sha1;
+use function sprintf;
+use function usleep;
+
+/**
+ * Database-level lock ensuring only a single migration run executes at a time, even across processes.
+ *
+ * - MySQL / MariaDB: session-level named lock via GET_LOCK() / RELEASE_LOCK()
+ * - PostgreSQL: session-level advisory lock via pg_try_advisory_lock() / pg_advisory_unlock()
+ * - other platforms (including SQLite): no-op (SQLite serializes writers at the filesystem level)
+ *
+ * The lock is bound to the connection session, so it is released automatically when the connection
+ * is closed - e.g. when a killed process drops its connection - preventing permanent dead-locks.
+ */
+class MigrationLock
+{
+
+    private const POSTGRES_POLL_INTERVAL_MICROSECONDS = 500_000; // 0.5s
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly string $lockName,
+        private readonly int $timeoutSeconds,
+    )
+    {
+    }
+
+    public function acquire(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof AbstractMySQLPlatform) {
+            $this->acquireMysql();
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $this->acquirePostgres();
+        }
+        // other platforms (incl. SQLite): no-op
+    }
+
+    public function release(): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof AbstractMySQLPlatform) {
+            $this->connection->executeQuery('SELECT RELEASE_LOCK(?)', [$this->getMysqlLockName()]);
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            $this->connection->executeQuery('SELECT pg_advisory_unlock(?)', [$this->getPostgresLockKey()]);
+        }
+        // other platforms (incl. SQLite): no-op
+    }
+
+    private function acquireMysql(): void
+    {
+        // GET_LOCK blocks server-side up to the given timeout; returns 1 on success, 0 on timeout, NULL on error
+        $result = $this->connection->fetchOne('SELECT GET_LOCK(?, ?)', [$this->getMysqlLockName(), $this->timeoutSeconds]);
+
+        if (!$this->isTruthy($result)) {
+            throw $this->createTimeoutException();
+        }
+    }
+
+    private function acquirePostgres(): void
+    {
+        // there is no built-in wait timeout for advisory locks, so poll pg_try_advisory_lock until a deadline
+        $key = $this->getPostgresLockKey();
+        $deadline = microtime(true) + $this->timeoutSeconds;
+
+        while (true) {
+            if ($this->isTruthy($this->connection->fetchOne('SELECT pg_try_advisory_lock(?)', [$key]))) {
+                return;
+            }
+
+            $remainingMicroseconds = (int) (($deadline - microtime(true)) * 1_000_000);
+
+            if ($remainingMicroseconds <= 0) {
+                throw $this->createTimeoutException();
+            }
+
+            // clamp the sleep to the remaining time so the wait does not overshoot the configured timeout
+            usleep(min(self::POSTGRES_POLL_INTERVAL_MICROSECONDS, $remainingMicroseconds));
+        }
+    }
+
+    private function getMysqlLockName(): string
+    {
+        // GET_LOCK names are server-wide, so scope them by database; SHA1 keeps the name within the 64-char limit
+        return sha1($this->lockName . '@' . ($this->connection->getDatabase() ?? ''));
+    }
+
+    private function getPostgresLockKey(): int
+    {
+        // advisory locks are already scoped per database; crc32 yields a stable integer usable as the bigint key
+        return crc32($this->lockName);
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        return $value === true || $value === 1 || $value === '1' || $value === 't';
+    }
+
+    private function createTimeoutException(): MigrationLockException
+    {
+        return new MigrationLockException($this->timeoutSeconds, sprintf(
+            'Could not acquire migration lock within %d seconds, another migration run is probably in progress.',
+            $this->timeoutSeconds,
+        ));
+    }
+
+}

--- a/src/MigrationLockException.php
+++ b/src/MigrationLockException.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+use RuntimeException;
+
+/**
+ * Thrown when the migration lock cannot be acquired within the configured timeout,
+ * typically because another migration run is already in progress.
+ *
+ * @api
+ */
+class MigrationLockException extends RuntimeException
+{
+
+    public function __construct(
+        public readonly int $timeoutSeconds,
+        string $message,
+    )
+    {
+        parent::__construct($message);
+    }
+
+}

--- a/src/MigrationService.php
+++ b/src/MigrationService.php
@@ -16,14 +16,20 @@ use ShipMonk\Doctrine\Migration\Event\MigrationExecutionFailedEvent;
 use ShipMonk\Doctrine\Migration\Event\MigrationExecutionStartedEvent;
 use ShipMonk\Doctrine\Migration\Event\MigrationExecutionSucceededEvent;
 use Throwable;
+use function array_map;
+use function count;
 use function file_put_contents;
+use function implode;
 use function is_string;
 use function ksort;
+use function sprintf;
 use function str_replace;
 use function strpos;
 
 class MigrationService
 {
+
+    private const DATETIME_FORMAT = 'Y-m-d H:i:s.u'; // string with microseconds, see initializeMigrationTable()
 
     private EntityManagerInterface $entityManager;
 
@@ -40,6 +46,8 @@ class MigrationService
     private ?EventDispatcherInterface $eventDispatcher;
 
     private MigrationGenerator $generator;
+
+    private ?MigrationLock $lock = null;
 
     public function __construct(
         EntityManagerInterface $entityManager,
@@ -76,6 +84,11 @@ class MigrationService
         return new $fqn();
     }
 
+    private function getQuotedMigrationTableName(): string
+    {
+        return $this->connection->getDatabasePlatform()->quoteSingleIdentifier($this->config->getMigrationTableName());
+    }
+
     public function executeMigration(
         string $version,
         MigrationPhase $phase,
@@ -86,13 +99,27 @@ class MigrationService
         $this->eventDispatcher?->dispatch(new MigrationExecutionStartedEvent($migration, $version, $phase));
 
         try {
+            // mark the start outside the (optional) body transaction, so an interrupted migration stays detectable
+            $startedAt = new DateTimeImmutable();
+            $this->markMigrationStarted($version, $phase, $startedAt);
+
+            $runBody = function () use ($migration, $phase): void {
+                match ($phase) {
+                    MigrationPhase::BEFORE => $migration->before($this->executor),
+                    MigrationPhase::AFTER => $migration->after($this->executor),
+                };
+            };
+
             if ($migration instanceof TransactionalMigration) {
-                $run = $this->connection->transactional(function () use ($migration, $version, $phase): MigrationRun {
-                    return $this->doExecuteMigration($migration, $version, $phase);
-                });
+                $this->connection->transactional($runBody);
             } else {
-                $run = $this->doExecuteMigration($migration, $version, $phase);
+                $runBody();
             }
+
+            $finishedAt = new DateTimeImmutable();
+            $this->markMigrationFinished($version, $phase, $finishedAt);
+
+            $run = new MigrationRun($version, $phase, $startedAt, $finishedAt);
 
             $this->eventDispatcher?->dispatch(new MigrationExecutionSucceededEvent($migration, $version, $phase));
 
@@ -100,27 +127,6 @@ class MigrationService
             $this->eventDispatcher?->dispatch(new MigrationExecutionFailedEvent($migration, $version, $phase, $e));
             throw $e;
         }
-
-        return $run;
-    }
-
-    private function doExecuteMigration(
-        Migration $migration,
-        string $version,
-        MigrationPhase $phase,
-    ): MigrationRun
-    {
-        $startTime = new DateTimeImmutable();
-
-        match ($phase) {
-            MigrationPhase::BEFORE => $migration->before($this->executor),
-            MigrationPhase::AFTER => $migration->after($this->executor),
-        };
-
-        $endTime = new DateTimeImmutable();
-        $run = new MigrationRun($version, $phase, $startTime, $endTime);
-
-        $this->markMigrationExecuted($run);
 
         return $run;
     }
@@ -163,7 +169,7 @@ class MigrationService
     {
         /** @var list<array{version: mixed}> $result */
         $result = $this->connection->executeQuery(
-            'SELECT version FROM migration WHERE phase = :phase',
+            'SELECT version FROM ' . $this->getQuotedMigrationTableName() . ' WHERE phase = :phase',
             [
                 'phase' => $phase->value,
             ],
@@ -186,23 +192,162 @@ class MigrationService
         return $versions;
     }
 
+    /**
+     * Returns migrations that were started but never finished (finished_at IS NULL), i.e. interrupted runs.
+     * Such migrations may be partially applied, so the system must not silently continue.
+     *
+     * @return list<array{version: string, phase: string, startedAt: string}>
+     */
+    public function getIncompleteMigrations(): array
+    {
+        /** @var list<array{version: mixed, phase: mixed, started_at: mixed}> $result */
+        $result = $this->connection->executeQuery(
+            'SELECT version, phase, started_at FROM ' . $this->getQuotedMigrationTableName() . ' WHERE finished_at IS NULL ORDER BY started_at',
+        )->fetchAllAssociative();
+
+        $incomplete = [];
+
+        foreach ($result as $row) {
+            $version = $row['version'];
+            $phase = $row['phase'];
+            $startedAt = $row['started_at'];
+
+            if (!is_string($version) || !is_string($phase) || !is_string($startedAt)) {
+                throw new LogicException('Version, phase and started_at should be strings.');
+            }
+
+            $incomplete[] = ['version' => $version, 'phase' => $phase, 'startedAt' => $startedAt];
+        }
+
+        return $incomplete;
+    }
+
+    /**
+     * @throws IncompleteMigrationException when there are migrations that were started but never finished
+     */
+    public function assertNoIncompleteMigrations(): void
+    {
+        $incomplete = $this->getIncompleteMigrations();
+
+        if ($incomplete === []) {
+            return;
+        }
+
+        $list = implode(', ', array_map(
+            static fn (array $migration): string => sprintf(
+                '%s (phase %s, started at %s)',
+                $migration['version'],
+                $migration['phase'],
+                $migration['startedAt'],
+            ),
+            $incomplete,
+        ));
+
+        throw new IncompleteMigrationException($incomplete, sprintf(
+            'Cannot run migrations, found %d unfinished migration(s) from a previously interrupted run: %s. '
+                . 'Such migrations may be partially applied. Verify the database state manually and then either delete the '
+                . 'row from the %s table to re-run the migration, or set its finished_at to mark it as completed.',
+            count($incomplete),
+            $list,
+            $this->config->getMigrationTableName(),
+        ));
+    }
+
+    /**
+     * Ensures the migration table exists and uses the current schema (finished_at nullable).
+     * Guards against running migrations after a library upgrade where migration:init was not re-run,
+     * which would otherwise fail with a cryptic NOT NULL constraint violation.
+     *
+     * @throws MigrationTableNotInitializedException
+     */
+    public function assertMigrationTableUpToDate(): void
+    {
+        $migrationTableName = $this->config->getMigrationTableName();
+        $schemaManager = $this->connection->createSchemaManager();
+
+        if (!$schemaManager->tablesExist([$migrationTableName])) {
+            throw new MigrationTableNotInitializedException($migrationTableName, sprintf(
+                'Migration table "%s" does not exist. Run the migration:init command before running migrations.',
+                $migrationTableName,
+            ));
+        }
+
+        $table = $schemaManager->introspectTable($migrationTableName);
+
+        if (!$table->hasColumn('finished_at') || $table->getColumn('finished_at')->getNotnull()) {
+            throw new MigrationTableNotInitializedException($migrationTableName, sprintf(
+                'Migration table "%s" schema is out of date (the finished_at column must exist and be nullable). '
+                    . 'Run the migration:init command to upgrade it before running migrations.',
+                $migrationTableName,
+            ));
+        }
+    }
+
     public function markMigrationExecuted(MigrationRun $run): void
     {
-        $microsecondsFormat = 'Y-m-d H:i:s.u';
         $this->connection->insert($this->config->getMigrationTableName(), [
             'version' => $run->getVersion(),
             'phase' => $run->getPhase()->value,
-            'started_at' => $run->getStartedAt()->format($microsecondsFormat),
-            'finished_at' => $run->getFinishedAt()->format($microsecondsFormat),
+            'started_at' => $run->getStartedAt()->format(self::DATETIME_FORMAT),
+            'finished_at' => $run->getFinishedAt()->format(self::DATETIME_FORMAT),
         ]);
     }
 
-    public function initializeMigrationTable(): bool
+    private function markMigrationStarted(
+        string $version,
+        MigrationPhase $phase,
+        DateTimeImmutable $startedAt,
+    ): void
+    {
+        $this->connection->insert($this->config->getMigrationTableName(), [
+            'version' => $version,
+            'phase' => $phase->value,
+            'started_at' => $startedAt->format(self::DATETIME_FORMAT),
+            'finished_at' => null,
+        ]);
+    }
+
+    private function markMigrationFinished(
+        string $version,
+        MigrationPhase $phase,
+        DateTimeImmutable $finishedAt,
+    ): void
+    {
+        $this->connection->update(
+            $this->config->getMigrationTableName(),
+            ['finished_at' => $finishedAt->format(self::DATETIME_FORMAT)],
+            ['version' => $version, 'phase' => $phase->value],
+        );
+    }
+
+    public function acquireLock(): void
+    {
+        $this->getLock()->acquire();
+    }
+
+    public function releaseLock(): void
+    {
+        $this->getLock()->release();
+    }
+
+    private function getLock(): MigrationLock
+    {
+        return $this->lock ??= new MigrationLock(
+            $this->connection,
+            $this->config->getMigrationTableName(),
+            $this->config->getLockTimeoutSeconds(),
+        );
+    }
+
+    /**
+     * Creates the migration table when missing, or idempotently upgrades it when present. Safe to run repeatedly.
+     */
+    public function initializeMigrationTable(): MigrationTableState
     {
         $migrationTableName = $this->config->getMigrationTableName();
 
         if ($this->connection->createSchemaManager()->tablesExist([$migrationTableName])) {
-            return false;
+            return $this->upgradeMigrationTable($migrationTableName);
         }
 
         $primaryKey = PrimaryKeyConstraint::editor()
@@ -214,14 +359,44 @@ class MigrationService
         $table->addColumn('version', 'string', ['length' => 20]);
         $table->addColumn('phase', 'string', ['length' => 10]);
         $table->addColumn('started_at', 'string', ['length' => 30]); // string to support microseconds
-        $table->addColumn('finished_at', 'string', ['length' => 30]);
+        $table->addColumn('finished_at', 'string', ['length' => 30, 'notnull' => false]); // nullable: NULL marks an unfinished (interrupted) migration
         $table->addPrimaryKeyConstraint($primaryKey);
 
         foreach ($schema->toSql($this->connection->getDatabasePlatform()) as $sql) {
-            $this->connection->executeQuery($sql);
+            $this->connection->executeStatement($sql);
         }
 
-        return true;
+        return MigrationTableState::Created;
+    }
+
+    /**
+     * Idempotently makes finished_at nullable on an already existing migration table (upgrade from < 2.0).
+     * Only this single column is touched, so no unrelated schema differences can be applied.
+     */
+    private function upgradeMigrationTable(
+        string $migrationTableName,
+    ): MigrationTableState
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $currentTable = $schemaManager->introspectTable($migrationTableName);
+
+        if (!$currentTable->hasColumn('finished_at') || !$currentTable->getColumn('finished_at')->getNotnull()) {
+            return MigrationTableState::AlreadyUpToDate;
+        }
+
+        $desiredTable = $schemaManager->introspectTable($migrationTableName);
+        $desiredTable->modifyColumn('finished_at', ['notnull' => false]);
+
+        $comparatorConfig = (new ComparatorConfig())->withReportModifiedIndexes(false);
+        $tableDiff = $schemaManager->createComparator($comparatorConfig)->compareTables($currentTable, $desiredTable);
+
+        if ($tableDiff->isEmpty()) {
+            return MigrationTableState::AlreadyUpToDate;
+        }
+
+        $schemaManager->alterTable($tableDiff);
+
+        return MigrationTableState::Upgraded;
     }
 
     /**

--- a/src/MigrationTableNotInitializedException.php
+++ b/src/MigrationTableNotInitializedException.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+use RuntimeException;
+
+/**
+ * Thrown when the migration table is missing or its schema is outdated (e.g. after upgrading the library
+ * without re-running migration:init). The remedy is always to run the migration:init command.
+ *
+ * @api
+ */
+class MigrationTableNotInitializedException extends RuntimeException
+{
+
+    public function __construct(
+        public readonly string $tableName,
+        string $message,
+    )
+    {
+        parent::__construct($message);
+    }
+
+}

--- a/src/MigrationTableState.php
+++ b/src/MigrationTableState.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+/**
+ * Outcome of {@see MigrationService::initializeMigrationTable()}.
+ *
+ * @api
+ */
+enum MigrationTableState
+{
+
+    case Created;
+    case Upgraded;
+    case AlreadyUpToDate;
+
+}

--- a/tests/Bridge/Symfony/TwoPhaseMigrationsBundleTest.php
+++ b/tests/Bridge/Symfony/TwoPhaseMigrationsBundleTest.php
@@ -39,6 +39,7 @@ class TwoPhaseMigrationsBundleTest extends TestCase
         self::assertSame([], $config['excluded_tables'] ?? null);
         self::assertNull($config['template_file_path'] ?? null);
         self::assertNull($config['template_indent'] ?? null);
+        self::assertNull($config['lock_timeout_seconds'] ?? null);
     }
 
     public function testConfigurationFull(): void
@@ -51,12 +52,14 @@ class TwoPhaseMigrationsBundleTest extends TestCase
             'excluded_tables' => ['tmp_table'],
             'template_file_path' => __DIR__ . '/../../../src/template/migration.txt',
             'template_indent' => "\t\t",
+            'lock_timeout_seconds' => 60,
         ]);
 
         self::assertSame('custom_table', $config['migration_table_name'] ?? null);
         self::assertSame('App\\Migrations', $config['migration_class_namespace'] ?? null);
         self::assertSame('Version', $config['migration_class_prefix'] ?? null);
         self::assertSame(['tmp_table'], $config['excluded_tables'] ?? null);
+        self::assertSame(60, $config['lock_timeout_seconds'] ?? null);
     }
 
     public function testConfigurationMissingRequired(): void

--- a/tests/Command/MigrationCheckCommandTest.php
+++ b/tests/Command/MigrationCheckCommandTest.php
@@ -48,4 +48,28 @@ class MigrationCheckCommandTest extends TestCase
         self::assertTrue($logger->hasMessage('Migration check completed'));
     }
 
+    public function testCheckReportsIncompleteMigrations(): void
+    {
+        $config = $this->createMock(MigrationConfig::class);
+        $config->method('getMigrationsDirectory')->willReturn('/tmp/migrations');
+
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->method('getIncompleteMigrations')->willReturn([
+            ['version' => 'v1', 'phase' => 'before', 'startedAt' => '2023-01-01 00:00:00.000000'],
+        ]);
+        $migrationService->method('getExecutedVersions')->willReturn(['fakeversion']);
+        $migrationService->method('getPreparedVersions')->willReturn(['fakeversion']);
+        $migrationService->method('generateDiffSqls')->willReturn([]);
+        $migrationService->method('getConfig')->willReturn($config);
+
+        $logger = new TestLogger();
+
+        $output = new BufferedOutput();
+        $command = new MigrationCheckCommand($migrationService, $logger);
+        $exitCode = $command->run(new ArrayInput([]), $output);
+
+        self::assertSame(MigrationCheckCommand::EXIT_INCOMPLETE_MIGRATION, $exitCode);
+        self::assertTrue($logger->hasMessage('Found {migrationIncompleteCount} unfinished migration(s) from a previously interrupted run, manual resolution is required: {migrationIncompleteList}'));
+    }
+
 }

--- a/tests/Command/MigrationInitCommandTest.php
+++ b/tests/Command/MigrationInitCommandTest.php
@@ -5,6 +5,7 @@ namespace ShipMonk\Doctrine\Migration\Command;
 use PHPUnit\Framework\TestCase;
 use ShipMonk\Doctrine\Migration\MigrationConfig;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationTableState;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -19,7 +20,7 @@ class MigrationInitCommandTest extends TestCase
         $migrationService = $this->createMock(MigrationService::class);
         $migrationService->expects(self::once())
             ->method('initializeMigrationTable')
-            ->willReturn(true);
+            ->willReturn(MigrationTableState::Created);
         $migrationService->method('getConfig')->willReturn($config);
 
         $logger = new TestLogger();
@@ -34,6 +35,28 @@ class MigrationInitCommandTest extends TestCase
         self::assertTrue($logger->hasMessage('Migration table {tableName} created successfully'));
     }
 
+    public function testInitUpgraded(): void
+    {
+        $config = $this->createMock(MigrationConfig::class);
+        $config->method('getMigrationTableName')->willReturn('migration');
+
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->expects(self::once())
+            ->method('initializeMigrationTable')
+            ->willReturn(MigrationTableState::Upgraded);
+        $migrationService->method('getConfig')->willReturn($config);
+
+        $logger = new TestLogger();
+
+        $output = new BufferedOutput();
+        $command = new MigrationInitCommand($migrationService, $logger);
+        $exitCode = $command->run(new ArrayInput([]), $output);
+
+        self::assertSame(0, $exitCode);
+
+        self::assertTrue($logger->hasMessage('Migration table {tableName} upgraded successfully'));
+    }
+
     public function testInitAlreadyExists(): void
     {
         $config = $this->createMock(MigrationConfig::class);
@@ -42,7 +65,7 @@ class MigrationInitCommandTest extends TestCase
         $migrationService = $this->createMock(MigrationService::class);
         $migrationService->expects(self::once())
             ->method('initializeMigrationTable')
-            ->willReturn(false);
+            ->willReturn(MigrationTableState::AlreadyUpToDate);
         $migrationService->method('getConfig')->willReturn($config);
 
         $logger = new TestLogger();

--- a/tests/Command/MigrationRunCommandTest.php
+++ b/tests/Command/MigrationRunCommandTest.php
@@ -4,9 +4,13 @@ namespace ShipMonk\Doctrine\Migration\Command;
 
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ShipMonk\Doctrine\Migration\IncompleteMigrationException;
+use ShipMonk\Doctrine\Migration\MigrationLockException;
 use ShipMonk\Doctrine\Migration\MigrationPhase;
 use ShipMonk\Doctrine\Migration\MigrationRun;
 use ShipMonk\Doctrine\Migration\MigrationService;
+use ShipMonk\Doctrine\Migration\MigrationTableNotInitializedException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -79,6 +83,73 @@ class MigrationRunCommandTest extends TestCase
         self::assertTrue($logger->hasMessage('Executing migration {migrationVersion} phase {migrationPhase}'));
         self::assertTrue($logger->hasMessage('Migration {migrationVersion} phase {migrationPhase} executed successfully, {migrationDurationSeconds} s elapsed'));
         self::assertTrue($logger->hasMessage('Migration execution completed (phase {migrationPhaseArgument})'));
+    }
+
+    public function testLockNotAcquiredReturnsExitCode(): void
+    {
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->method('acquireLock')
+            ->willThrowException(new MigrationLockException(300, 'cannot acquire lock'));
+        $migrationService->expects(self::never())->method('executeMigration');
+        $migrationService->expects(self::never())->method('releaseLock'); // nothing acquired, nothing to release
+
+        $logger = new TestLogger();
+        $command = new MigrationRunCommand($migrationService, $logger);
+        $exitCode = $this->runPhase($command, MigrationPhase::BEFORE->value);
+
+        self::assertSame(MigrationRunCommand::EXIT_LOCK_NOT_ACQUIRED, $exitCode);
+        self::assertTrue($logger->hasMessage('Migration execution aborted, could not acquire migration lock within {migrationLockTimeoutSeconds} s (another migration run is probably in progress)'));
+    }
+
+    public function testTableNotInitializedReturnsExitCode(): void
+    {
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->method('assertMigrationTableUpToDate')
+            ->willThrowException(new MigrationTableNotInitializedException('migration', 'run migration:init'));
+        $migrationService->expects(self::once())->method('releaseLock');
+        $migrationService->expects(self::never())->method('executeMigration');
+
+        $logger = new TestLogger();
+        $command = new MigrationRunCommand($migrationService, $logger);
+        $exitCode = $this->runPhase($command, MigrationPhase::BEFORE->value);
+
+        self::assertSame(MigrationRunCommand::EXIT_TABLE_NOT_INITIALIZED, $exitCode);
+        self::assertTrue($logger->hasMessage('Migration execution aborted, migration table {migrationTableName} is not initialized, run the migration:init command first'));
+    }
+
+    public function testIncompleteMigrationReturnsExitCode(): void
+    {
+        $incomplete = [['version' => 'v1', 'phase' => 'before', 'startedAt' => '2023-01-01 00:00:00.000000']];
+
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->method('assertNoIncompleteMigrations')
+            ->willThrowException(new IncompleteMigrationException($incomplete, 'incomplete migration detected'));
+        $migrationService->expects(self::once())->method('releaseLock'); // lock acquired, must be released
+        $migrationService->expects(self::never())->method('executeMigration');
+
+        $logger = new TestLogger();
+        $command = new MigrationRunCommand($migrationService, $logger);
+        $exitCode = $this->runPhase($command, MigrationPhase::BEFORE->value);
+
+        self::assertSame(MigrationRunCommand::EXIT_INCOMPLETE_MIGRATION, $exitCode);
+        self::assertTrue($logger->hasMessage('Migration execution aborted, found {migrationIncompleteCount} unfinished migration(s) from a previously interrupted run, manual resolution is required'));
+    }
+
+    public function testReleaseLockFailureDoesNotMaskResult(): void
+    {
+        $migrationService = $this->createMock(MigrationService::class);
+        $migrationService->method('getExecutedVersions')->willReturn([]);
+        $migrationService->method('getPreparedVersions')->willReturn([]);
+        $migrationService->method('releaseLock')
+            ->willThrowException(new RuntimeException('connection lost'));
+
+        $logger = new TestLogger();
+        $command = new MigrationRunCommand($migrationService, $logger);
+        $exitCode = $this->runPhase($command, MigrationPhase::BEFORE->value);
+
+        // the run succeeded, so a failing lock release must not turn it into a failure
+        self::assertSame(MigrationRunCommand::EXIT_OK, $exitCode);
+        self::assertTrue($logger->hasMessage('Failed to release the migration lock, it will be released when the database connection is closed ({migrationError})'));
     }
 
     public function testFailureNoArgs(): void

--- a/tests/MigrationLockTest.php
+++ b/tests/MigrationLockTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\Doctrine\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use PHPUnit\Framework\TestCase;
+use function crc32;
+use function sha1;
+
+class MigrationLockTest extends TestCase
+{
+
+    public function testNoOpOnSqlite(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new SQLitePlatform());
+        $connection->expects(self::never())->method('fetchOne');
+        $connection->expects(self::never())->method('executeQuery');
+
+        $lock = new MigrationLock($connection, 'migration', 300);
+        $lock->acquire();
+        $lock->release();
+    }
+
+    public function testMysqlAcquireAndRelease(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new MySQLPlatform());
+        $connection->method('getDatabase')->willReturn('testdb');
+
+        $expectedName = sha1('migration@testdb');
+
+        $connection->expects(self::once())
+            ->method('fetchOne')
+            ->with('SELECT GET_LOCK(?, ?)', [$expectedName, 5])
+            ->willReturn(1);
+
+        $connection->expects(self::once())
+            ->method('executeQuery')
+            ->with('SELECT RELEASE_LOCK(?)', [$expectedName]);
+
+        $lock = new MigrationLock($connection, 'migration', 5);
+        $lock->acquire();
+        $lock->release();
+    }
+
+    public function testMysqlAcquireTimeoutThrows(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new MySQLPlatform());
+        $connection->method('getDatabase')->willReturn('testdb');
+        $connection->method('fetchOne')->willReturn(0); // 0 = GET_LOCK timed out
+
+        $lock = new MigrationLock($connection, 'migration', 5);
+
+        $this->expectException(MigrationLockException::class);
+        $this->expectExceptionMessage('within 5 seconds');
+
+        try {
+            $lock->acquire();
+        } catch (MigrationLockException $e) {
+            self::assertSame(5, $e->timeoutSeconds);
+
+            throw $e;
+        }
+    }
+
+    public function testPostgresAcquireAndRelease(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new PostgreSQLPlatform());
+
+        $expectedKey = crc32('migration');
+
+        $connection->expects(self::once())
+            ->method('fetchOne')
+            ->with('SELECT pg_try_advisory_lock(?)', [$expectedKey])
+            ->willReturn(true);
+
+        $connection->expects(self::once())
+            ->method('executeQuery')
+            ->with('SELECT pg_advisory_unlock(?)', [$expectedKey]);
+
+        $lock = new MigrationLock($connection, 'migration', 5);
+        $lock->acquire();
+        $lock->release();
+    }
+
+    public function testPostgresAcquireTimeoutThrows(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new PostgreSQLPlatform());
+        $connection->method('fetchOne')->willReturn(false); // lock not free
+
+        $lock = new MigrationLock($connection, 'migration', 0); // 0s timeout = try once then fail without sleeping
+
+        $this->expectException(MigrationLockException::class);
+        $lock->acquire();
+    }
+
+}

--- a/tests/MigrationServiceTest.php
+++ b/tests/MigrationServiceTest.php
@@ -2,12 +2,14 @@
 
 namespace ShipMonk\Doctrine\Migration;
 
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use ShipMonk\Doctrine\Migration\Event\MigrationExecutionStartedEvent;
 use ShipMonk\Doctrine\Migration\Event\MigrationExecutionSucceededEvent;
+use Throwable;
 use function array_map;
 use function file_get_contents;
 use function glob;
@@ -50,8 +52,8 @@ class MigrationServiceTest extends TestCase
 
         $sqls = $service->generateDiffSqls();
 
-        self::assertTrue($initialized1);
-        self::assertFalse($initialized2);
+        self::assertSame(MigrationTableState::Created, $initialized1);
+        self::assertSame(MigrationTableState::AlreadyUpToDate, $initialized2);
         self::assertSame(['CREATE TABLE entity (id VARCHAR(255) NOT NULL, PRIMARY KEY (id))'], $sqls);
 
         self::assertEquals([], $service->getExecutedVersions(MigrationPhase::BEFORE));
@@ -123,9 +125,10 @@ class MigrationServiceTest extends TestCase
         $transactionalService->executeMigration($transactionalMigrationFile->version, MigrationPhase::BEFORE);
 
         self::assertSame([
+            'INSERT INTO migration (version, phase, started_at, finished_at) VALUES (?, ?, ?, ?)', // start marker, committed before the body
             'Beginning transaction',
-            'INSERT INTO migration (version, phase, started_at, finished_at) VALUES (?, ?, ?, ?)',
             'Committing transaction',
+            'UPDATE migration SET finished_at = ? WHERE version = ? AND phase = ?', // finish marker, after the body
         ], $logger->getQueriesPerformed());
 
         $logger->clean();
@@ -133,7 +136,8 @@ class MigrationServiceTest extends TestCase
         $nonTransactionalService->executeMigration($nonTransactionalMigrationFile->version, MigrationPhase::BEFORE);
 
         self::assertSame([
-            'INSERT INTO migration (version, phase, started_at, finished_at) VALUES (?, ?, ?, ?)',
+            'INSERT INTO migration (version, phase, started_at, finished_at) VALUES (?, ?, ?, ?)', // start marker
+            'UPDATE migration SET finished_at = ? WHERE version = ? AND phase = ?', // finish marker
         ], $logger->getQueriesPerformed());
     }
 
@@ -169,9 +173,10 @@ class MigrationServiceTest extends TestCase
         $migrationsService->executeMigration($migrationFile->version, MigrationPhase::BEFORE);
 
         self::assertSame([
+            'INSERT INTO migration (version, phase, started_at, finished_at) VALUES (?, ?, ?, ?)',
             'SELECT 1',
             'SELECT 3',
-            'INSERT INTO migration (version, phase, started_at, finished_at) VALUES (?, ?, ?, ?)',
+            'UPDATE migration SET finished_at = ? WHERE version = ? AND phase = ?',
         ], $logger->getQueriesPerformed());
 
         $logger->clean();
@@ -179,8 +184,9 @@ class MigrationServiceTest extends TestCase
         $migrationsService->executeMigration($migrationFile->version, MigrationPhase::AFTER);
 
         self::assertSame([
-            'SELECT 2',
             'INSERT INTO migration (version, phase, started_at, finished_at) VALUES (?, ?, ?, ?)',
+            'SELECT 2',
+            'UPDATE migration SET finished_at = ? WHERE version = ? AND phase = ?',
         ], $logger->getQueriesPerformed());
     }
 
@@ -210,8 +216,9 @@ class MigrationServiceTest extends TestCase
         $migrationsService->executeMigration($migrationFile->version, MigrationPhase::BEFORE);
 
         self::assertSame([
-            'SELECT 1',
             'INSERT INTO migration (version, phase, started_at, finished_at) VALUES (?, ?, ?, ?)',
+            'SELECT 1',
+            'UPDATE migration SET finished_at = ? WHERE version = ? AND phase = ?',
         ], $logger->getQueriesPerformed());
 
         $logger->clean();
@@ -219,8 +226,9 @@ class MigrationServiceTest extends TestCase
         $migrationsService->executeMigration($migrationFile->version, MigrationPhase::AFTER);
 
         self::assertSame([
-            'SELECT 2',
             'INSERT INTO migration (version, phase, started_at, finished_at) VALUES (?, ?, ?, ?)',
+            'SELECT 2',
+            'UPDATE migration SET finished_at = ? WHERE version = ? AND phase = ?',
         ], $logger->getQueriesPerformed());
     }
 
@@ -229,7 +237,7 @@ class MigrationServiceTest extends TestCase
         [$entityManager] = $this->createEntityManagerAndLogger();
         $service = $this->createMigrationService($entityManager);
 
-        self::assertTrue($service->initializeMigrationTable());
+        self::assertSame(MigrationTableState::Created, $service->initializeMigrationTable());
 
         $migrationTableName = $service->getConfig()->getMigrationTableName();
         $schemaManager = $entityManager->getConnection()->createSchemaManager();
@@ -240,7 +248,255 @@ class MigrationServiceTest extends TestCase
         self::assertTrue($table->hasColumn('phase'));
         self::assertTrue($table->hasColumn('started_at'));
         self::assertTrue($table->hasColumn('finished_at'));
+        self::assertTrue($table->getColumn('started_at')->getNotnull());
+        self::assertFalse($table->getColumn('finished_at')->getNotnull()); // nullable: NULL marks an unfinished migration
         self::assertNotNull($table->getPrimaryKeyConstraint());
+
+        self::assertSame(MigrationTableState::AlreadyUpToDate, $service->initializeMigrationTable());
+    }
+
+    public function testInitializeUpgradesFinishedAtToNullable(): void
+    {
+        [$entityManager] = $this->createEntityManagerAndLogger();
+        $service = $this->createMigrationService($entityManager);
+        $connection = $entityManager->getConnection();
+        $migrationTableName = $service->getConfig()->getMigrationTableName();
+
+        // simulate the pre-2.0 schema where finished_at was NOT NULL
+        $connection->executeStatement(
+            "CREATE TABLE {$migrationTableName} ("
+                . 'version VARCHAR(20) NOT NULL, '
+                . 'phase VARCHAR(10) NOT NULL, '
+                . 'started_at VARCHAR(30) NOT NULL, '
+                . 'finished_at VARCHAR(30) NOT NULL, '
+                . 'PRIMARY KEY (version, phase))',
+        );
+        $connection->insert($migrationTableName, [
+            'version' => 'v1',
+            'phase' => 'before',
+            'started_at' => '2023-01-01 00:00:00.000000',
+            'finished_at' => '2023-01-01 00:00:01.000000',
+        ]);
+
+        self::assertTrue($entityManager->getConnection()->createSchemaManager()->introspectTable($migrationTableName)->getColumn('finished_at')->getNotnull());
+
+        $upgraded = $service->initializeMigrationTable();
+
+        self::assertSame(MigrationTableState::Upgraded, $upgraded);
+
+        $table = $entityManager->getConnection()->createSchemaManager()->introspectTable($migrationTableName);
+        self::assertFalse($table->getColumn('finished_at')->getNotnull());
+        self::assertNotNull($table->getPrimaryKeyConstraint());
+
+        // data preserved and a NULL finished_at can now be stored
+        self::assertSame(['v1' => 'v1'], $service->getExecutedVersions(MigrationPhase::BEFORE));
+        $connection->insert($migrationTableName, ['version' => 'v2', 'phase' => 'before', 'started_at' => '2023-01-02 00:00:00.000000', 'finished_at' => null]);
+        self::assertSame([['version' => 'v2', 'phase' => 'before', 'startedAt' => '2023-01-02 00:00:00.000000']], $service->getIncompleteMigrations());
+
+        self::assertSame(MigrationTableState::AlreadyUpToDate, $service->initializeMigrationTable()); // idempotent, no further upgrade
+    }
+
+    public function testGetIncompleteMigrations(): void
+    {
+        [$entityManager] = $this->createEntityManagerAndLogger();
+        $service = $this->createMigrationService($entityManager);
+        $connection = $entityManager->getConnection();
+        $migrationTableName = $service->getConfig()->getMigrationTableName();
+
+        $service->initializeMigrationTable();
+
+        self::assertSame([], $service->getIncompleteMigrations());
+        $service->assertNoIncompleteMigrations(); // does not throw
+
+        // a finished migration is not reported as incomplete
+        $connection->insert($migrationTableName, ['version' => 'v1', 'phase' => 'before', 'started_at' => '2023-01-01 00:00:00.000000', 'finished_at' => '2023-01-01 00:00:01.000000']);
+        // an interrupted migration leaves finished_at = NULL
+        $connection->insert($migrationTableName, ['version' => 'v2', 'phase' => 'after', 'started_at' => '2023-01-02 00:00:00.000000', 'finished_at' => null]);
+
+        self::assertSame([
+            ['version' => 'v2', 'phase' => 'after', 'startedAt' => '2023-01-02 00:00:00.000000'],
+        ], $service->getIncompleteMigrations());
+    }
+
+    public function testAssertNoIncompleteMigrationsThrows(): void
+    {
+        [$entityManager] = $this->createEntityManagerAndLogger();
+        $service = $this->createMigrationService($entityManager);
+        $connection = $entityManager->getConnection();
+        $migrationTableName = $service->getConfig()->getMigrationTableName();
+
+        $service->initializeMigrationTable();
+        $connection->insert($migrationTableName, ['version' => 'v1', 'phase' => 'before', 'started_at' => '2023-01-01 00:00:00.000000', 'finished_at' => null]);
+
+        try {
+            $service->assertNoIncompleteMigrations();
+            self::fail('Expected IncompleteMigrationException');
+        } catch (IncompleteMigrationException $e) {
+            self::assertSame([['version' => 'v1', 'phase' => 'before', 'startedAt' => '2023-01-01 00:00:00.000000']], $e->incompleteMigrations);
+            self::assertStringContainsString('v1', $e->getMessage());
+        }
+    }
+
+    public function testInterruptedMigrationLeavesIncompleteMarker(): void
+    {
+        $versionProvider = new class implements MigrationVersionProvider {
+
+            public function getNextVersion(): string
+            {
+                return 'failing1';
+            }
+
+        };
+        [$entityManager] = $this->createEntityManagerAndLogger();
+        $service = $this->createMigrationService($entityManager, versionProvider: $versionProvider);
+
+        $service->initializeMigrationTable();
+
+        $migrationFile = $service->generateMigrationFile(['THIS IS NOT VALID SQL']);
+        require $migrationFile->filePath;
+
+        // the migration body fails, but the start marker must persist so the failure is detected later
+        try {
+            $service->executeMigration($migrationFile->version, MigrationPhase::BEFORE);
+            self::fail('Expected the migration body to fail');
+        } catch (Throwable $e) {
+            self::assertNotSame('', $e->getMessage());
+        }
+
+        $incomplete = $service->getIncompleteMigrations();
+        self::assertCount(1, $incomplete);
+        self::assertSame('failing1', $incomplete[0]['version']);
+        self::assertSame('before', $incomplete[0]['phase']);
+
+        // and the next run must refuse to continue
+        self::expectException(IncompleteMigrationException::class);
+        $service->assertNoIncompleteMigrations();
+    }
+
+    public function testAssertMigrationTableUpToDateThrowsWhenTableMissing(): void
+    {
+        [$entityManager] = $this->createEntityManagerAndLogger();
+        $service = $this->createMigrationService($entityManager);
+
+        try {
+            $service->assertMigrationTableUpToDate();
+            self::fail('Expected MigrationTableNotInitializedException');
+        } catch (MigrationTableNotInitializedException $e) {
+            self::assertSame('migration', $e->tableName);
+            self::assertStringContainsString('migration:init', $e->getMessage());
+        }
+    }
+
+    public function testAssertMigrationTableUpToDateThrowsOnOutdatedSchema(): void
+    {
+        [$entityManager] = $this->createEntityManagerAndLogger();
+        $service = $this->createMigrationService($entityManager);
+        $connection = $entityManager->getConnection();
+        $migrationTableName = $service->getConfig()->getMigrationTableName();
+
+        // pre-2.0 schema with finished_at NOT NULL
+        $connection->executeStatement(
+            "CREATE TABLE {$migrationTableName} (version VARCHAR(20) NOT NULL, phase VARCHAR(10) NOT NULL, "
+                . 'started_at VARCHAR(30) NOT NULL, finished_at VARCHAR(30) NOT NULL, PRIMARY KEY (version, phase))',
+        );
+
+        try {
+            $service->assertMigrationTableUpToDate();
+            self::fail('Expected MigrationTableNotInitializedException');
+        } catch (MigrationTableNotInitializedException $e) {
+            self::assertStringContainsString('out of date', $e->getMessage());
+        }
+
+        // after init upgrades the schema, the assertion passes
+        $service->initializeMigrationTable();
+        $service->assertMigrationTableUpToDate();
+    }
+
+    public function testAssertMigrationTableUpToDateThrowsWhenFinishedAtColumnMissing(): void
+    {
+        [$entityManager] = $this->createEntityManagerAndLogger();
+        $service = $this->createMigrationService($entityManager);
+        $connection = $entityManager->getConnection();
+        $migrationTableName = $service->getConfig()->getMigrationTableName();
+
+        // table exists but has no finished_at column at all
+        $connection->executeStatement(
+            "CREATE TABLE {$migrationTableName} (version VARCHAR(20) NOT NULL, phase VARCHAR(10) NOT NULL, "
+                . 'started_at VARCHAR(30) NOT NULL, PRIMARY KEY (version, phase))',
+        );
+
+        try {
+            $service->assertMigrationTableUpToDate();
+            self::fail('Expected MigrationTableNotInitializedException');
+        } catch (MigrationTableNotInitializedException $e) {
+            self::assertStringContainsString('out of date', $e->getMessage());
+            self::assertStringContainsString('migration:init', $e->getMessage());
+        }
+    }
+
+    public function testReadsHonorCustomMigrationTableName(): void
+    {
+        [$entityManager] = $this->createEntityManagerAndLogger();
+        $service = $this->createMigrationService($entityManager, migrationTableName: 'custom_migration_table');
+        $connection = $entityManager->getConnection();
+
+        self::assertSame('custom_migration_table', $service->getConfig()->getMigrationTableName());
+
+        $service->initializeMigrationTable();
+        self::assertTrue($connection->createSchemaManager()->tablesExist(['custom_migration_table']));
+
+        $connection->insert('custom_migration_table', ['version' => 'v1', 'phase' => 'before', 'started_at' => '2023-01-01 00:00:00.000000', 'finished_at' => '2023-01-01 00:00:01.000000']);
+        $connection->insert('custom_migration_table', ['version' => 'v2', 'phase' => 'after', 'started_at' => '2023-01-02 00:00:00.000000', 'finished_at' => null]);
+
+        self::assertSame(['v1' => 'v1'], $service->getExecutedVersions(MigrationPhase::BEFORE));
+        self::assertSame([['version' => 'v2', 'phase' => 'after', 'startedAt' => '2023-01-02 00:00:00.000000']], $service->getIncompleteMigrations());
+    }
+
+    public function testAcquireAndReleaseLockDoesNotThrow(): void
+    {
+        [$entityManager, $logger] = $this->createEntityManagerAndLogger();
+        $service = $this->createMigrationService($entityManager);
+        $service->initializeMigrationTable();
+        $logger->clean();
+
+        $service->acquireLock();
+        $service->releaseLock();
+
+        if ($entityManager->getConnection()->getDatabasePlatform() instanceof SQLitePlatform) {
+            self::assertSame([], $logger->getQueriesPerformed()); // SQLite locking is a no-op
+        } else {
+            self::assertNotSame([], $logger->getQueriesPerformed()); // MySQL/PostgreSQL ran real lock SQL
+        }
+    }
+
+    public function testLockPreventsConcurrentAcquire(): void
+    {
+        [$entityManager] = $this->createEntityManagerAndLogger();
+
+        if ($entityManager->getConnection()->getDatabasePlatform() instanceof SQLitePlatform) {
+            self::markTestSkipped('SQLite locking is a no-op (writers are serialized at the filesystem level)');
+        }
+
+        // a second, independent connection/session to the same database
+        [$entityManager2] = $this->createEntityManagerAndLogger();
+
+        $serviceA = $this->createMigrationService($entityManager);
+        $serviceB = $this->createMigrationService($entityManager2, lockTimeoutSeconds: 1);
+
+        $serviceA->acquireLock();
+
+        try {
+            $serviceB->acquireLock();
+            self::fail('Expected MigrationLockException, the lock is held by another session');
+        } catch (MigrationLockException $e) {
+            self::assertSame(1, $e->timeoutSeconds);
+        } finally {
+            $serviceA->releaseLock();
+        }
+
+        // once released, the lock can be acquired again
+        $serviceB->acquireLock();
+        $serviceB->releaseLock();
     }
 
     public function testGetPreparedVersions(): void
@@ -290,6 +546,8 @@ class MigrationServiceTest extends TestCase
         ?MigrationVersionProvider $versionProvider = null,
         ?MigrationAnalyzer $statementAnalyzer = null,
         ?EventDispatcherInterface $eventDispatcher = null,
+        ?string $migrationTableName = null,
+        ?int $lockTimeoutSeconds = null,
     ): MigrationService
     {
         $migrationsDir = $this->getMigrationsTestDir();
@@ -311,7 +569,7 @@ class MigrationServiceTest extends TestCase
             $entityManager,
             new MigrationConfig(
                 $migrationsDir,
-                null,
+                $migrationTableName,
                 null,
                 null,
                 $excludedTables,
@@ -319,6 +577,7 @@ class MigrationServiceTest extends TestCase
                     ? __DIR__ . '/templates/transactional.txt'
                     : __DIR__ . '/templates/non-transactional.txt',
                 null,
+                $lockTimeoutSeconds,
             ),
             null,
             $versionProvider,


### PR DESCRIPTION
## Why

Today `migration:run` is unsafe in two ways:

- **Killed mid-run** — `markMigrationExecuted` only records a migration *after* its body succeeds. On MySQL, DDL auto-commits and cannot be rolled back, so a killed process leaves a partially-applied migration with **no record**. The next run silently re-executes it.
- **Run in parallel** — two concurrent runs both compute "pending" and both execute the same migration.

This PR makes the command **safe to run multiple times and in parallel**, where *safe* means it never silently corrupts the database (not that every invocation finishes the work) — the definition agreed in the team thread that motivated this.

## How

Two mechanisms, modeled on [`nextras/migrations`](https://github.com/nextras/migrations/blob/master/src/Engine/OrderResolver.php#L53-L56):

### 1. Record the start before executing → fail loudly on interrupted migrations
`finished_at` becomes **nullable**. The start marker (`finished_at = NULL`) is committed **before** the migration body and **outside** any transaction; only the body is wrapped in a transaction for a `TransactionalMigration`. So a migration interrupted mid-run leaves a durable `finished_at = NULL` row that survives:
- a body **rollback** on PostgreSQL (the marker is not inside the body transaction), and
- a **DDL implicit commit** on MySQL.

Every subsequent `migration:run` then **fails loudly** (exit 1) instead of re-running potentially non-idempotent SQL, until an operator resolves the row (delete it to re-run, or set `finished_at` to mark it done).

### 2. Serialize runs with a database lock
`migration:run` acquires a lock before reading state and executing, releasing it in a `finally`:
- **MySQL/MariaDB** — `GET_LOCK` / `RELEASE_LOCK`
- **PostgreSQL** — `pg_try_advisory_lock` / `pg_advisory_unlock`
- **SQLite / other** — no-op (single-writer)

A parallel run waits up to `lock_timeout_seconds` (default `300`, configurable) and then either proceeds (finding nothing to do, exit 0) or aborts (exit 2). The lock is session-bound, so a killed runner releases it automatically.

## Also included
- `migration:init` idempotently **upgrades an existing table** by making `finished_at` nullable (narrow single-column `ALTER` via a one-column `TableDiff`, not a full schema diff — no spurious changes). Safe to run repeatedly.
- A guard turns the "upgraded the library but didn't re-run `migration:init`" trap into an actionable error (exit 3) instead of a cryptic `NOT NULL` violation.
- `migration:check` reports unfinished migrations (adds `8` to its exit bitmask).
- Drive-by: `getExecutedVersions()` now honors a custom migration table name (was hardcoded `migration`); raw-SELECT identifiers are quoted.
- New exit codes for `migration:run`: `0` ok, `1` unfinished migration, `2` lock not acquired, `3` table missing / not upgraded.
- README "Concurrency & execution safety" section; new `lock_timeout_seconds` config (also wired through the Symfony bundle).

## Backward compatibility
This is a behavioral + schema change (effectively a major release):
- `finished_at` becomes nullable — **run `migration:init` once after upgrading** to migrate the table.
- The new incomplete-migration check can now block runs (by design).

## Tests
Rebased on top of #144, so the suite now runs against **SQLite, MySQL and PostgreSQL** in CI. Coverage added:
- interrupted migration leaves a marker and blocks the next run;
- `migration:init` upgrades `finished_at` to nullable preserving data + PK;
- **`testLockPreventsConcurrentAcquire`** — acquires the lock on one connection and asserts a second connection times out, proving mutual exclusion on real MySQL/PostgreSQL (skipped on SQLite, which is a no-op);
- lock SQL per platform via mocked connection (`MigrationLockTest`);
- custom table name honored; new exit codes.

All of `composer check` passes (phpstan max + strict + dead-code, phpcs, deps, phpunit). Verified locally against SQLite and PostgreSQL; MySQL via CI.

Co-Authored-By: Claude Code