### PR TITLE
Run test suite against real SQLite, MySQL and PostgreSQL in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,6 +29,7 @@ jobs:
                 run: composer check
 
 
+    # SQLite needs no service container; this job carries the broad PHP × dependency compatibility matrix.
     tests:
         runs-on: ubuntu-latest
         strategy:
@@ -36,17 +37,32 @@ jobs:
             matrix:
                 php-version: [ '8.2', '8.3', '8.4', '8.5' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
-                database: [ sqlite, mysql, pgsql ]
-                include:
-                    -
-                        database: sqlite
-                        database-url: ''
-                    -
-                        database: mysql
-                        database-url: 'pdo-mysql://root:root@127.0.0.1:3306/migrations'
-                    -
-                        database: pgsql
-                        database-url: 'pdo-pgsql://postgres:postgres@127.0.0.1:5432/migrations'
+        steps:
+            -
+                name: Checkout code
+                uses: actions/checkout@v6
+            -
+                name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-version }}
+                    extensions: pdo_sqlite
+            -
+                name: Update dependencies
+                run: composer update --no-progress --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
+            -
+                name: Run tests against SQLite
+                run: composer check:tests
+
+    # MySQL/PostgreSQL compatibility tracks the DBAL version (the dependency-version axis), so these run
+    # on a single representative PHP version and only start the one database they actually need.
+    tests-mysql:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                dependency-version: [ prefer-lowest, prefer-stable ]
         services:
             mysql:
                 image: mysql:8.4
@@ -60,6 +76,33 @@ jobs:
                     --health-interval=10s
                     --health-timeout=5s
                     --health-retries=10
+        steps:
+            -
+                name: Checkout code
+                uses: actions/checkout@v6
+            -
+                name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 8.4
+                    extensions: pdo_mysql
+            -
+                name: Update dependencies
+                run: composer update --no-progress --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
+            -
+                name: Run tests against MySQL
+                run: composer check:tests
+                env:
+                    DATABASE_URL: 'pdo-mysql://root:root@127.0.0.1:3306/migrations'
+
+    tests-pgsql:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                dependency-version: [ prefer-lowest, prefer-stable ]
+        services:
             postgres:
                 image: postgres:16
                 env:
@@ -80,15 +123,15 @@ jobs:
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: ${{ matrix.php-version }}
-                    extensions: pdo_sqlite, pdo_mysql, pdo_pgsql
+                    php-version: 8.4
+                    extensions: pdo_pgsql
             -
                 name: Update dependencies
                 run: composer update --no-progress --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             -
-                name: Run tests against ${{ matrix.database }}
+                name: Run tests against PostgreSQL
                 run: composer check:tests
                 env:
-                    DATABASE_URL: ${{ matrix.database-url }}
+                    DATABASE_URL: 'pdo-pgsql://postgres:postgres@127.0.0.1:5432/migrations'
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,6 +36,42 @@ jobs:
             matrix:
                 php-version: [ '8.2', '8.3', '8.4', '8.5' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
+                database: [ sqlite, mysql, pgsql ]
+                include:
+                    -
+                        database: sqlite
+                        database-url: ''
+                    -
+                        database: mysql
+                        database-url: 'pdo-mysql://root:root@127.0.0.1:3306/migrations'
+                    -
+                        database: pgsql
+                        database-url: 'pdo-pgsql://postgres:postgres@127.0.0.1:5432/migrations'
+        services:
+            mysql:
+                image: mysql:8.4
+                env:
+                    MYSQL_ROOT_PASSWORD: root
+                    MYSQL_DATABASE: migrations
+                ports:
+                    - 3306:3306
+                options: >-
+                    --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=10
+            postgres:
+                image: postgres:16
+                env:
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: migrations
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd="pg_isready -U postgres"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=10
         steps:
             -
                 name: Checkout code
@@ -45,11 +81,14 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php-version }}
+                    extensions: pdo_sqlite, pdo_mysql, pdo_pgsql
             -
                 name: Update dependencies
                 run: composer update --no-progress --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             -
-                name: Run tests
+                name: Run tests against ${{ matrix.database }}
                 run: composer check:tests
+                env:
+                    DATABASE_URL: ${{ matrix.database-url }}
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.4
+                    php-version: 8.5
             -
                 name: Install dependencies
                 run: composer install --no-progress --prefer-dist --no-interaction
@@ -84,7 +84,7 @@ jobs:
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.4
+                    php-version: 8.5
                     extensions: pdo_mysql
             -
                 name: Update dependencies
@@ -123,7 +123,7 @@ jobs:
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.4
+                    php-version: 8.5
                     extensions: pdo_pgsql
             -
                 name: Update dependencies

--- a/tests/WithEntityManagerTestCase.php
+++ b/tests/WithEntityManagerTestCase.php
@@ -2,16 +2,20 @@
 
 namespace ShipMonk\Doctrine\Migration;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Tools\DsnParser;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
-use function gc_collect_cycles;
-use function is_file;
-use function unlink;
+use function getenv;
+use function is_string;
 
+/**
+ * @phpstan-import-type Params from DriverManager
+ */
 trait WithEntityManagerTestCase
 {
 
@@ -21,13 +25,6 @@ trait WithEntityManagerTestCase
     public function createEntityManagerAndLogger(): array
     {
         $tmpDir = __DIR__ . '/../tmp';
-
-        $databaseFile = $tmpDir . '/db.sqlite';
-
-        if (is_file($databaseFile)) {
-            gc_collect_cycles();
-            unlink($databaseFile);
-        }
 
         $logger = new CachingSqlLogger();
 
@@ -40,14 +37,55 @@ trait WithEntityManagerTestCase
         $config->setMetadataDriverImpl(new AttributeDriver([__DIR__]));
         $config->setMiddlewares([new CachingSqlLoggerMiddleware($logger)]);
 
-        $connection = DriverManager::getConnection([
-            'driver' => 'pdo_sqlite',
-            'path' => $databaseFile,
-        ], $config);
+        $connection = DriverManager::getConnection(self::getConnectionParams($tmpDir), $config);
+
+        self::dropAllTables($connection);
 
         $entityManager = new EntityManager($connection, $config);
 
         return [$entityManager, $logger];
+    }
+
+    /**
+     * Connection params are read from the DATABASE_URL environment variable (Doctrine DSN format),
+     * falling back to a local SQLite file when it is not set. This lets the same test suite run
+     * against SQLite, MySQL and PostgreSQL just by changing the environment.
+     *
+     * @return Params
+     */
+    private static function getConnectionParams(string $tmpDir): array
+    {
+        $databaseUrl = getenv('DATABASE_URL');
+
+        if (is_string($databaseUrl) && $databaseUrl !== '') {
+            $dsnParser = new DsnParser([
+                'sqlite' => 'pdo_sqlite',
+                'mysql' => 'pdo_mysql',
+                'mariadb' => 'pdo_mysql',
+                'postgres' => 'pdo_pgsql',
+                'postgresql' => 'pdo_pgsql',
+                'pgsql' => 'pdo_pgsql',
+            ]);
+
+            return $dsnParser->parse($databaseUrl);
+        }
+
+        return [
+            'driver' => 'pdo_sqlite',
+            'path' => $tmpDir . '/db.sqlite',
+        ];
+    }
+
+    /**
+     * Ensures every test starts with an empty schema regardless of the platform.
+     */
+    private static function dropAllTables(Connection $connection): void
+    {
+        $schemaManager = $connection->createSchemaManager();
+
+        foreach ($schemaManager->listTableNames() as $tableName) {
+            $schemaManager->dropTable($tableName);
+        }
     }
 
 }


### PR DESCRIPTION
## Why

CI previously ran the test suite against **SQLite only**. Since schema introspection and DDL generation behave differently per database platform, the library's behavior on MySQL and PostgreSQL was effectively untested.

## What

- **`WithEntityManagerTestCase`** now builds the connection from a `DATABASE_URL` environment variable (Doctrine DSN format), falling back to the local SQLite file when it is unset. The same test suite therefore runs unchanged on any platform. Inter-test schema cleanup is now done generically by dropping all tables (works on every platform) instead of deleting the SQLite file.
- **CI** is split into focused jobs so each starts only the database it needs:
  - `tests` — broad PHP × dependency matrix (8.2–8.5 × prefer-lowest/prefer-stable) on **SQLite**, no service containers.
  - `tests-mysql` — prefer-lowest + prefer-stable on a **MySQL 8.4** service container.
  - `tests-pgsql` — prefer-lowest + prefer-stable on a **PostgreSQL 16** service container.
- MySQL/PostgreSQL compatibility tracks the `doctrine/dbal` version (the dependency-version axis) rather than the PHP version, so the per-database jobs run on a single representative PHP version (**8.5**). The `checks` job also runs on PHP 8.5.

## Verification

Ran the full suite locally against all three engines via real containers — **23 tests / 146 assertions pass identically** on SQLite, MySQL 8.4 and PostgreSQL 16, and the full pipeline is green (13 jobs). No assertion changes were needed: with `doctrine/dbal` ^4.3 the generated DDL (e.g. `CREATE TABLE entity (id VARCHAR(255) NOT NULL, PRIMARY KEY (id))`) is identical across platforms for this schema.

Co-Authored-By: Claude Code